### PR TITLE
Fix SW push event silently dropped on Android Chrome

### DIFF
--- a/src/ServiceWorkerRule/WorkboxHelpers.php
+++ b/src/ServiceWorkerRule/WorkboxHelpers.php
@@ -295,7 +295,7 @@ function registerPushTask(callback) {
   pushTasks.push(callback);
 }
 self.addEventListener('push', (event) => {
-    if (!(self.Notification && self.Notification.permission === 'granted')) {
+    if (typeof self.Notification !== 'undefined' && self.Notification.permission === 'denied') {
         return;
     }
     event.waitUntil(


### PR DESCRIPTION
## Summary

The push event listener in the generated service worker gates on
`self.Notification.permission === 'granted'` before running the registered
push tasks. On Android Chrome the `Notification` constructor is exposed in
the Service Worker global scope but the static `.permission` property
returns `undefined`, so the check fails and every push is dropped silently:
the SW wakes up, decrypts the payload, and exits before `showNotification`
is ever called. The same code path works on desktop Chrome and Firefox where
`Notification.permission` is consistently exposed.

The browser already requires an active push subscription (which itself
requires `granted` permission) to deliver a push event, so the in-handler
check is mostly defensive against revocation between subscribe and delivery.
This PR bails out only when permission is explicitly `denied`, which is
observable on every platform that exposes the Notifications API to workers.

## Reproduction

1. Install a PWA based on this bundle on Android Chrome.
2. Subscribe to push and send a valid encrypted payload.
3. Open ``chrome://gcm-internals/`` on the device — the FCM message is
   delivered.
4. Inspect the SW via remote DevTools — ``self.Notification.permission``
   returns ``undefined`` and the push event handler returns without
   dispatching any registered push task.

## Test plan

- [x] Verified on Android Chrome with a real FCM subscription: notification
      now displays after the change.
- [x] Verified on desktop Chrome (Linux): behavior unchanged.
- [ ] Verified on Firefox desktop.
- [ ] Verified on Safari (when applicable).