### PR TITLE
Fix `pwa:compile` command display

### DIFF
--- a/src/Service/FileCompiler.php
+++ b/src/Service/FileCompiler.php
@@ -61,6 +61,7 @@ final class FileCompiler implements CanLogInterface
                 $this->assetsFilesystem->write($data->url, $data->getData());
             }
             $progressBar?->finish();
+            $io?->newLine(2);
         }
         $this->logger->debug('Files compiled.');
     }


### PR DESCRIPTION
Target branch: `1.6.x`
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Add 2 new lines at the end of each file compiler to fix display of `pwa:compile` command.

Here is a screenshot showing the command run twice: the first time without the fix, and the second time with it:
<img width="2560" height="1048" alt="Capture d’écran 2026-05-29 222453" src="https://github.com/user-attachments/assets/86cc2d4f-9da4-4c0c-b4e3-ae371be242e5" />
