### PR TITLE
[codex] Fix Symfony 8.1 tagged service rule priorities

### DIFF
--- a/src/Service/ServiceWorkerCompiler.php
+++ b/src/Service/ServiceWorkerCompiler.php
@@ -39,7 +39,7 @@ final class ServiceWorkerCompiler implements FileCompilerInterface, CanLogInterf
     public function __construct(
         ServiceWorkerBuilder $serviceWorkerBuilder,
         private readonly AssetMapperInterface $assetMapper,
-        #[AutowireIterator('spomky_labs_pwa.service_worker_rule', defaultPriorityMethod: 'getPriority')]
+        #[AutowireIterator('spomky_labs_pwa.service_worker_rule')]
         private readonly iterable $serviceworkerRules,
         #[Autowire(param: 'kernel.debug')]
         public readonly bool $debug,

--- a/src/ServiceWorkerRule/NavigationPreload.php
+++ b/src/ServiceWorkerRule/NavigationPreload.php
@@ -9,7 +9,9 @@ use Psr\Log\NullLogger;
 use SpomkyLabs\PwaBundle\Dto\Workbox;
 use SpomkyLabs\PwaBundle\Service\CanLogInterface;
 use SpomkyLabs\PwaBundle\Service\ServiceWorkerBuilder;
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 
+#[AsTaggedItem(priority: 1022)]
 final class NavigationPreload implements ServiceWorkerRuleInterface, CanLogInterface
 {
     private readonly Workbox $workbox;
@@ -68,13 +70,6 @@ DEBUG_COMMENT;
         ]);
 
         return $declaration;
-    }
-
-    public static function getPriority(): int
-    {
-        // Must run after WorkboxImport (1024) and WorkboxHelpers (1023)
-        // but before cache strategies
-        return 1022;
     }
 
     public function setLogger(LoggerInterface $logger): void

--- a/src/ServiceWorkerRule/WorkboxHelpers.php
+++ b/src/ServiceWorkerRule/WorkboxHelpers.php
@@ -6,7 +6,9 @@ namespace SpomkyLabs\PwaBundle\ServiceWorkerRule;
 
 use SpomkyLabs\PwaBundle\Dto\Workbox;
 use SpomkyLabs\PwaBundle\Service\ServiceWorkerBuilder;
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 
+#[AsTaggedItem(priority: 1023)]
 final readonly class WorkboxHelpers implements ServiceWorkerRuleInterface
 {
     private Workbox $workbox;
@@ -409,8 +411,4 @@ async function openCache(name) {
 CUSTOM_HELPERS;
     }
 
-    public static function getPriority(): int
-    {
-        return 1023;
-    }
 }

--- a/src/ServiceWorkerRule/WorkboxImport.php
+++ b/src/ServiceWorkerRule/WorkboxImport.php
@@ -10,7 +10,9 @@ use Psr\Log\NullLogger;
 use SpomkyLabs\PwaBundle\Dto\Workbox;
 use SpomkyLabs\PwaBundle\Service\CanLogInterface;
 use SpomkyLabs\PwaBundle\Service\ServiceWorkerBuilder;
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 
+#[AsTaggedItem(priority: 1024)]
 final class WorkboxImport implements ServiceWorkerRuleInterface, CanLogInterface
 {
     private readonly Workbox $workbox;
@@ -102,11 +104,6 @@ DEBUG_COMMENT;
         ]);
 
         return $declaration;
-    }
-
-    public static function getPriority(): int
-    {
-        return 1024;
     }
 
     public function setLogger(LoggerInterface $logger): void

--- a/tests/Unit/ServiceWorkerRule/NavigationPreloadTest.php
+++ b/tests/Unit/ServiceWorkerRule/NavigationPreloadTest.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace SpomkyLabs\PwaBundle\Tests\Unit\ServiceWorkerRule;
 
+use ReflectionClass;
+
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use SpomkyLabs\PwaBundle\Dto\ServiceWorker;
 use SpomkyLabs\PwaBundle\Dto\Workbox;
 use SpomkyLabs\PwaBundle\Service\ServiceWorkerBuilder;
 use SpomkyLabs\PwaBundle\ServiceWorkerRule\NavigationPreload;
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 /**
@@ -106,11 +109,13 @@ final class NavigationPreloadTest extends TestCase
     }
 
     #[Test]
-    public function itHasCorrectPriority(): void
+    public function itHasCorrectTaggedItemPriority(): void
     {
         // Navigation Preload should run after WorkboxImport (1024) and WorkboxHelpers (1023)
         // but before cache strategies
-        static::assertSame(1022, NavigationPreload::getPriority());
+        $attribute = (new ReflectionClass(NavigationPreload::class))->getAttributes(AsTaggedItem::class)[0];
+
+        static::assertSame(1022, $attribute->getArguments()['priority']);
     }
 
     private function createNavigationPreloadRule(Workbox $workbox): NavigationPreload

--- a/tests/Unit/ServiceWorkerRule/WorkboxImportTest.php
+++ b/tests/Unit/ServiceWorkerRule/WorkboxImportTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SpomkyLabs\PwaBundle\Tests\Unit\ServiceWorkerRule;
 
+use ReflectionClass;
+
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use SpomkyLabs\PwaBundle\Dto\ServiceWorker;
@@ -11,6 +13,7 @@ use SpomkyLabs\PwaBundle\Dto\Workbox;
 use SpomkyLabs\PwaBundle\Dto\WorkboxConfig;
 use SpomkyLabs\PwaBundle\Service\ServiceWorkerBuilder;
 use SpomkyLabs\PwaBundle\ServiceWorkerRule\WorkboxImport;
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 /**
@@ -170,10 +173,12 @@ final class WorkboxImportTest extends TestCase
     }
 
     #[Test]
-    public function itHasCorrectPriority(): void
+    public function itHasCorrectTaggedItemPriority(): void
     {
         // WorkboxImport should have highest priority
-        static::assertSame(1024, WorkboxImport::getPriority());
+        $attribute = (new ReflectionClass(WorkboxImport::class))->getAttributes(AsTaggedItem::class)[0];
+
+        static::assertSame(1024, $attribute->getArguments()['priority']);
     }
 
     private function createWorkboxImportRule(Workbox $workbox): WorkboxImport


### PR DESCRIPTION
Replaces the deprecated TaggedIterator default priority method with AsTaggedItem priorities on the three service-worker rules. This preserves their execution order while avoiding Symfony 8.1 DI deprecations. Focused rule tests and PHP syntax checks pass.