### PR TITLE
Fail explicitly when the image processor's PHP extension is missing

### DIFF
--- a/src/SpomkyLabsPwaBundle.php
+++ b/src/SpomkyLabsPwaBundle.php
@@ -4,18 +4,36 @@ declare(strict_types=1);
 
 namespace SpomkyLabs\PwaBundle;
 
+use function extension_loaded;
 use function in_array;
 use SpomkyLabs\PwaBundle\CompilerPass\LoggerCompilerPass;
 use SpomkyLabs\PwaBundle\CompilerPass\PreloadUrlCompilerPass;
 use SpomkyLabs\PwaBundle\EventListener\PwaDevServerListener;
+use SpomkyLabs\PwaBundle\ImageProcessor\GDImageProcessor;
 use SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface;
+use SpomkyLabs\PwaBundle\ImageProcessor\ImagickImageProcessor;
+use function sprintf;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
 
 final class SpomkyLabsPwaBundle extends AbstractBundle
 {
+    /**
+     * The built-in image processors are only registered when the PHP extension they
+     * are built on is loaded (see Resources/config/services.php).
+     *
+     * @var array<string, string>
+     */
+    private const IMAGE_PROCESSOR_EXTENSIONS = [
+        'pwa.image_processor.imagick' => 'imagick',
+        ImagickImageProcessor::class => 'imagick',
+        'pwa.image_processor.gd' => 'gd',
+        GDImageProcessor::class => 'gd',
+    ];
+
     protected string $extensionAlias = 'pwa';
 
     public function configure(DefinitionConfigurator $definition): void
@@ -39,6 +57,7 @@ final class SpomkyLabsPwaBundle extends AbstractBundle
         /** @var string|null $imageProcessor */
         $imageProcessor = $config['image_processor'];
         if ($imageProcessor !== null) {
+            $this->checkImageProcessorRequirements($imageProcessor);
             $builder->setAlias(ImageProcessorInterface::class, $imageProcessor);
         }
 
@@ -116,6 +135,26 @@ final class SpomkyLabsPwaBundle extends AbstractBundle
     public function prependExtension(ContainerConfigurator $container, ContainerBuilder $builder): void
     {
         $this->setAssetMapperPath($builder);
+    }
+
+    /**
+     * Aliasing a built-in processor whose PHP extension is missing would otherwise fail
+     * much later, inside AutowirePass, with a bare "You have requested a non-existent
+     * service pwa.image_processor.imagick" that points at the container instead of at
+     * the missing extension.
+     */
+    private function checkImageProcessorRequirements(string $imageProcessor): void
+    {
+        $extension = self::IMAGE_PROCESSOR_EXTENSIONS[$imageProcessor] ?? null;
+        if ($extension === null || extension_loaded($extension)) {
+            return;
+        }
+
+        throw new InvalidConfigurationException(sprintf(
+            'The image processor "%s" is configured under "pwa.image_processor" but the "%s" PHP extension is not loaded. Enable it, or select another image processor.',
+            $imageProcessor,
+            $extension
+        ));
     }
 
     private function setAssetMapperPath(ContainerBuilder $builder): void


### PR DESCRIPTION
## Problem

`pwa.image_processor.imagick` and `pwa.image_processor.gd` are only registered when the matching PHP extension is loaded:

```php
// src/Resources/config/services.php
if (extension_loaded('imagick')) {
    $container->set(ImagickImageProcessor::class)
        ->alias('pwa.image_processor.imagick', ImagickImageProcessor::class);
}
```

but the alias built from the `pwa.image_processor` option is registered unconditionally:

```php
// src/SpomkyLabsPwaBundle.php
$builder->setAlias(ImageProcessorInterface::class, $imageProcessor);
```

So on a runtime where the extension is missing, a perfectly ordinary configuration:

```yaml
pwa:
    image_processor: 'imagick'
```

makes the container blow up much later, inside `AutowirePass`:

```
Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException:
You have requested a non-existent service "pwa.image_processor.imagick"
```

The message points at the container rather than at the actual cause, and in a FrankenPHP worker it surfaces as a raw fatal at `preBoot()` — no Symfony error page, no hint that a PHP extension is missing. I lost a fair amount of time on it in a project where a container had been built by a PHP binary without `ext-imagick`.

## Change

`loadExtension()` now checks the requirement before aliasing, for both the shorthands and the explicit FQCN, and throws:

```
The image processor "pwa.image_processor.imagick" is configured under
"pwa.image_processor" but the "imagick" PHP extension is not loaded.
Enable it, or select another image processor.
```

Behaviour is unchanged when the extension is present, and a custom (non-built-in) processor service is left untouched.

## Notes

No test: `extension_loaded()` cannot be faked in-process, so covering the failing branch would require injecting the extension list into the bundle. Happy to do it that way if you prefer.