### PR TITLE
Fix Symfony 8.1 deprecations on tagged service worker rules

### DIFF
--- a/src/Service/ServiceWorkerCompiler.php
+++ b/src/Service/ServiceWorkerCompiler.php
@@ -39,7 +39,7 @@ final class ServiceWorkerCompiler implements FileCompilerInterface, CanLogInterf
     public function __construct(
         ServiceWorkerBuilder $serviceWorkerBuilder,
         private readonly AssetMapperInterface $assetMapper,
-        #[AutowireIterator('spomky_labs_pwa.service_worker_rule', defaultPriorityMethod: 'getPriority')]
+        #[AutowireIterator('spomky_labs_pwa.service_worker_rule')]
         private readonly iterable $serviceworkerRules,
         #[Autowire(param: 'kernel.debug')]
         public readonly bool $debug,

--- a/src/ServiceWorkerRule/NavigationPreload.php
+++ b/src/ServiceWorkerRule/NavigationPreload.php
@@ -9,7 +9,10 @@ use Psr\Log\NullLogger;
 use SpomkyLabs\PwaBundle\Dto\Workbox;
 use SpomkyLabs\PwaBundle\Service\CanLogInterface;
 use SpomkyLabs\PwaBundle\Service\ServiceWorkerBuilder;
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 
+// Must run after WorkboxImport (1024) and WorkboxHelpers (1023) but before cache strategies
+#[AsTaggedItem(priority: 1022)]
 final class NavigationPreload implements ServiceWorkerRuleInterface, CanLogInterface
 {
     private readonly Workbox $workbox;
@@ -68,13 +71,6 @@ DEBUG_COMMENT;
         ]);
 
         return $declaration;
-    }
-
-    public static function getPriority(): int
-    {
-        // Must run after WorkboxImport (1024) and WorkboxHelpers (1023)
-        // but before cache strategies
-        return 1022;
     }
 
     public function setLogger(LoggerInterface $logger): void

--- a/src/ServiceWorkerRule/WorkboxHelpers.php
+++ b/src/ServiceWorkerRule/WorkboxHelpers.php
@@ -6,7 +6,9 @@ namespace SpomkyLabs\PwaBundle\ServiceWorkerRule;
 
 use SpomkyLabs\PwaBundle\Dto\Workbox;
 use SpomkyLabs\PwaBundle\Service\ServiceWorkerBuilder;
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 
+#[AsTaggedItem(priority: 1023)]
 final readonly class WorkboxHelpers implements ServiceWorkerRuleInterface
 {
     private Workbox $workbox;
@@ -408,10 +410,5 @@ async function openCache(name) {
 }
 
 CUSTOM_HELPERS;
-    }
-
-    public static function getPriority(): int
-    {
-        return 1023;
     }
 }

--- a/src/ServiceWorkerRule/WorkboxImport.php
+++ b/src/ServiceWorkerRule/WorkboxImport.php
@@ -10,7 +10,9 @@ use Psr\Log\NullLogger;
 use SpomkyLabs\PwaBundle\Dto\Workbox;
 use SpomkyLabs\PwaBundle\Service\CanLogInterface;
 use SpomkyLabs\PwaBundle\Service\ServiceWorkerBuilder;
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 
+#[AsTaggedItem(priority: 1024)]
 final class WorkboxImport implements ServiceWorkerRuleInterface, CanLogInterface
 {
     private readonly Workbox $workbox;
@@ -102,11 +104,6 @@ DEBUG_COMMENT;
         ]);
 
         return $declaration;
-    }
-
-    public static function getPriority(): int
-    {
-        return 1024;
     }
 
     public function setLogger(LoggerInterface $logger): void

--- a/tests/Functional/ServiceWorkerRuleOrderTest.php
+++ b/tests/Functional/ServiceWorkerRuleOrderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Tests\Functional;
+
+use function array_slice;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionProperty;
+use SpomkyLabs\PwaBundle\Service\ServiceWorkerCompiler;
+use SpomkyLabs\PwaBundle\ServiceWorkerRule\NavigationPreload;
+use SpomkyLabs\PwaBundle\ServiceWorkerRule\ServiceWorkerRuleInterface;
+use SpomkyLabs\PwaBundle\ServiceWorkerRule\WorkboxHelpers;
+use SpomkyLabs\PwaBundle\ServiceWorkerRule\WorkboxImport;
+
+/**
+ * The Workbox import must be written first, then its helpers, then the navigation preload. That
+ * relative order comes from the #[AsTaggedItem] priorities carried by the rules themselves.
+ *
+ * @internal
+ */
+final class ServiceWorkerRuleOrderTest extends AbstractPwaTestCase
+{
+    #[Test]
+    public static function theHighestPriorityRulesAreAppliedFirst(): void
+    {
+        // Given
+        $compiler = self::getContainer()->get(ServiceWorkerCompiler::class);
+        static::assertInstanceOf(ServiceWorkerCompiler::class, $compiler);
+
+        // When
+        /** @var iterable<ServiceWorkerRuleInterface> $rules */
+        $rules = (new ReflectionProperty($compiler, 'serviceworkerRules'))->getValue($compiler);
+        $classes = [];
+        foreach ($rules as $rule) {
+            $classes[] = $rule::class;
+        }
+
+        // Then
+        static::assertSame(
+            [WorkboxImport::class, WorkboxHelpers::class, NavigationPreload::class],
+            array_slice($classes, 0, 3)
+        );
+    }
+}

--- a/tests/Unit/ServiceWorkerRule/NavigationPreloadTest.php
+++ b/tests/Unit/ServiceWorkerRule/NavigationPreloadTest.php
@@ -6,10 +6,12 @@ namespace SpomkyLabs\PwaBundle\Tests\Unit\ServiceWorkerRule;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use SpomkyLabs\PwaBundle\Dto\ServiceWorker;
 use SpomkyLabs\PwaBundle\Dto\Workbox;
 use SpomkyLabs\PwaBundle\Service\ServiceWorkerBuilder;
 use SpomkyLabs\PwaBundle\ServiceWorkerRule\NavigationPreload;
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 /**
@@ -110,7 +112,10 @@ final class NavigationPreloadTest extends TestCase
     {
         // Navigation Preload should run after WorkboxImport (1024) and WorkboxHelpers (1023)
         // but before cache strategies
-        static::assertSame(1022, NavigationPreload::getPriority());
+        $attributes = (new ReflectionClass(NavigationPreload::class))->getAttributes(AsTaggedItem::class);
+
+        static::assertCount(1, $attributes);
+        static::assertSame(1022, $attributes[0]->newInstance()->priority);
     }
 
     private function createNavigationPreloadRule(Workbox $workbox): NavigationPreload

--- a/tests/Unit/ServiceWorkerRule/WorkboxImportTest.php
+++ b/tests/Unit/ServiceWorkerRule/WorkboxImportTest.php
@@ -6,11 +6,13 @@ namespace SpomkyLabs\PwaBundle\Tests\Unit\ServiceWorkerRule;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use SpomkyLabs\PwaBundle\Dto\ServiceWorker;
 use SpomkyLabs\PwaBundle\Dto\Workbox;
 use SpomkyLabs\PwaBundle\Dto\WorkboxConfig;
 use SpomkyLabs\PwaBundle\Service\ServiceWorkerBuilder;
 use SpomkyLabs\PwaBundle\ServiceWorkerRule\WorkboxImport;
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 /**
@@ -173,7 +175,10 @@ final class WorkboxImportTest extends TestCase
     public function itHasCorrectPriority(): void
     {
         // WorkboxImport should have highest priority
-        static::assertSame(1024, WorkboxImport::getPriority());
+        $attributes = (new ReflectionClass(WorkboxImport::class))->getAttributes(AsTaggedItem::class);
+
+        static::assertCount(1, $attributes);
+        static::assertSame(1024, $attributes[0]->newInstance()->priority);
     }
 
     private function createWorkboxImportRule(Workbox $workbox): WorkboxImport


### PR DESCRIPTION
Target branch: 1.5.x
Resolves issue #444

- [x] It is a Bug fix
- [ ] It is a New feature
- [x] Breaks BC
- [ ] Includes Deprecations

## Problem

`symfony/dependency-injection` 8.1 deprecates the `$defaultIndexMethod` / `$defaultPriorityMethod` arguments of tagged locators and iterators, and the static default methods they call.

The `spomky_labs_pwa.service_worker_rule` iterator relied on both, so compiling the container emitted four deprecations — enough to fail projects with a strict deprecation policy:

```
The $defaultIndexMethod and $defaultPriorityMethod arguments of tagged locators and
iterators are deprecated, use the #[AsTaggedItem] attribute instead.
(tag: "spomky_labs_pwa.service_worker_rule")

Calling "…\ServiceWorkerRule\WorkboxImport::getPriority()" to get the "priority" index
is deprecated, use the #[AsTaggedItem] attribute instead.
(idem for WorkboxHelpers and NavigationPreload)
```

Note that the two causes are independent: passing `defaultPriorityMethod` triggers a deprecation on its own, whatever the rules look like.

## Solution

- `ServiceWorkerCompiler`: drop `defaultPriorityMethod: 'getPriority'` from the `#[AutowireIterator]`.
- `WorkboxImport`, `WorkboxHelpers`, `NavigationPreload`: replace the static `getPriority()` with `#[AsTaggedItem(priority: 1024 | 1023 | 1022)]`.

`#[AsTaggedItem]` is honoured from Symfony 6.1 onwards, so the resulting order is identical on every supported version. It is read only for autoconfigured definitions, which is the case here (`services.php` enables `autoconfigure()` in its defaults).

## Tests

- The two `itHasCorrectPriority` unit tests now assert the attribute instead of the removed method.
- New `ServiceWorkerRuleOrderTest` asserts the effective order of the rules injected from the compiled container. This is the real regression guard: it fails if `#[AsTaggedItem]` ever stops being taken into account.

Verified locally:

| | Before | After |
|---|---|---|
| Deprecations while compiling the container (Symfony 8.1) | 4 | **0** |
| Rule order | `WorkboxImport → WorkboxHelpers → NavigationPreload → …` | *unchanged* |

- Symfony 8.1 / PHP 8.5: full suite green (107 tests), deptrac 0 violation.
- Symfony 6.4 / PHP 8.2 (`--prefer-lowest`, as in CI): order preserved, tests green.

## BC break

`WorkboxImport::getPriority()`, `WorkboxHelpers::getPriority()` and `NavigationPreload::getPriority()` are removed. The classes are `final` and the methods are not documented anywhere, so the direct impact should be nil.

The behavioural change worth mentioning in the release notes: a **third-party** rule implementing `ServiceWorkerRuleInterface` with a static `getPriority()` silently loses its priority, since the iterator no longer looks for that method. Migration is to add `#[AsTaggedItem(priority: …)]` on the rule (or a `priority` attribute on the tag).

## Out of scope

Point 3 of the issue — adding Symfony 8.1 deprecation checks to CI — is not addressed here. `.ci-tools/phpunit.xml.dist` sets `SYMFONY_DEPRECATIONS_HELPER=disabled`; enabling it surfaces unrelated vendor deprecations and deserves its own PR.
