### PR TITLE
Deprecate the Stimulus controllers shipped by the bundle

### DIFF
--- a/assets/README.md
+++ b/assets/README.md
@@ -1,5 +1,22 @@
 # @spomky-labs/pwa-bundle
 
+> [!WARNING]
+> **Deprecated since 1.6.0, removed in 2.0.0.**
+>
+> These controllers are leaving the bundle. Wrapping a browser API in a generic, configurable
+> Stimulus controller turns out to be a lot of abstraction for very little reuse: every project
+> wants its own behaviour, its own UI and its own error handling. Several of them also push
+> real-time, client-side interactions through the server and back, a round trip nobody really
+> asks for.
+>
+> The bundle keeps what it does well: the web manifest, the service worker, the favicons and the
+> icons.
+>
+> **What to do:** copy the controllers you use into your own application and register them there.
+> They are plain Stimulus controllers with no dependency on the bundle, so nothing is lost. The
+> full rationale is in
+> [this comment](https://github.com/Spomky-Labs/pwa-bundle/issues/372#issuecomment-5295710299).
+
 Web APIs Stimulus controllers for your Progressive Web Applications.
 
 This package provides ready-to-use [Stimulus](https://stimulus.hotwired.dev/) controllers that leverage modern Web APIs to enhance your Progressive Web Applications with native-like features.

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@spomky-labs/pwa-bundle",
-    "description": "Web APIs Stimulus Controllers for Progressive Web Applications",
+    "description": "DEPRECATED, removed in 2.0.0 - Web APIs Stimulus Controllers for Progressive Web Applications",
     "license": "MIT",
     "version": "0.0.0-development",
     "main": "src/index.js",

--- a/assets/src/abstract_controller.js
+++ b/assets/src/abstract_controller.js
@@ -1,9 +1,18 @@
 'use strict';
 
 import { Controller } from '@hotwired/stimulus';
+import { reportDeprecatedController } from './deprecation.js';
 
 export default class extends Controller {
     component = undefined;
+
+    // In the constructor rather than connect(): fifteen controllers override connect()
+    // without calling super, so the warning would never fire for them. A derived class
+    // has no choice but to call super() here.
+    constructor(...args) {
+        super(...args);
+        reportDeprecatedController(this.identifier);
+    }
 
     async loadLiveComponent() {
         try {

--- a/assets/src/deprecation.js
+++ b/assets/src/deprecation.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const reported = new Set();
+
+/**
+ * Warns that a Stimulus controller shipped by the bundle is on its way out.
+ *
+ * Reported once per controller identifier: a page mounting the same controller on twenty
+ * elements should not print the same line twenty times.
+ *
+ * @param {string|undefined} identifier
+ */
+export const reportDeprecatedController = (identifier) => {
+    const name = identifier || 'pwa';
+    if (reported.has(name)) {
+        return;
+    }
+    reported.add(name);
+
+    console.warn(
+        `[pwa-bundle] The "${name}" Stimulus controller is deprecated since 1.6.0 and will be removed in 2.0.0. ` +
+        'Copy the controller into your own application and register it there. ' +
+        'See https://github.com/Spomky-Labs/pwa-bundle/issues/372#issuecomment-5295710299'
+    );
+};
+
+/**
+ * Same for the page-side helpers exported by the package.
+ *
+ * @param {string} name
+ * @param {string} replacement
+ */
+export const reportDeprecatedHelper = (name, replacement) => {
+    if (reported.has(name)) {
+        return;
+    }
+    reported.add(name);
+
+    console.warn(
+        `[pwa-bundle] ${name}() is deprecated since 1.6.0 and will be removed in 2.0.0. ${replacement} ` +
+        'See https://github.com/Spomky-Labs/pwa-bundle/issues/372#issuecomment-5295710299'
+    );
+};

--- a/assets/src/helpers.js
+++ b/assets/src/helpers.js
@@ -1,4 +1,10 @@
+import { reportDeprecatedHelper } from './deprecation.js';
+
 function onPeriodicSync(tag, callback) {
+    reportDeprecatedHelper(
+        'onPeriodicSync',
+        'Listen to your own BroadcastChannel instead: the service worker side of this protocol goes away too.'
+    );
     const periodicChannel = new BroadcastChannel('periodic-sync');
     periodicChannel.addEventListener('message', (event) => {
         const { type, tag: receivedTag, ...data } = event.data || {};
@@ -9,6 +15,10 @@ function onPeriodicSync(tag, callback) {
 }
 
 async function registerPeriodicSync(tag, minInterval, options = {}) {
+    reportDeprecatedHelper(
+        'registerPeriodicSync',
+        'Call registration.periodicSync.register() directly, it is a handful of lines.'
+    );
     const reg = await navigator.serviceWorker.ready;
     const status = await navigator.permissions.query({
         name: 'periodic-background-sync',

--- a/assets/src/network-information_controller.js
+++ b/assets/src/network-information_controller.js
@@ -1,8 +1,15 @@
 'use strict';
 
 import { Controller } from '@hotwired/stimulus';
+import { reportDeprecatedController } from './deprecation.js';
 
+// The only controller not extending AbstractController, so it carries the notice itself.
 export default class extends Controller {
+  constructor(...args) {
+    super(...args);
+    reportDeprecatedController(this.identifier);
+  }
+
   connect() {
     const connection = navigator.connection;
     connection.addEventListener('change', this.updateConnectionStatus);


### PR DESCRIPTION
Second step of the scope reduction announced in #372, independent from #455 which covers the service worker helpers. Nothing is removed here: the 27 controllers keep working exactly as before, they just say out loud that they are going away in 2.0.0.

## Where the notice sits

In the `AbstractController` **constructor**, not in `connect()`.

Fifteen of the twenty-seven controllers override `connect()` without calling `super.connect()`, so a base-class hook there would silently never fire for them. No controller defines a constructor, and a derived class has no choice but to call `super()`, so the constructor is the only airtight seam.

`NetworkInformationController` is the one controller extending Stimulus' `Controller` directly rather than `AbstractController`, so it carries the notice itself.

The warning is reported **once per controller identifier**: a page mounting the same controller on twenty elements should not print the same line twenty times.

```
[pwa-bundle] The "pwa--web-push" Stimulus controller is deprecated since 1.6.0 and will be
removed in 2.0.0. Copy the controller into your own application and register it there.
See https://github.com/Spomky-Labs/pwa-bundle/issues/372#issuecomment-5295710299
```

## Page-side helpers

`onPeriodicSync()` and `registerPeriodicSync()`, exported through the `@spomky-labs/pwa/helpers` importmap entry, warn too. Their service worker counterpart (`registerPeriodicSyncTask`, `notifyPeriodicSyncClients`) is deprecated in #455, so both halves of that protocol leave together.

## Package metadata

The npm README gets a deprecation banner and the package description is prefixed. The registry-level `npm deprecate @spomky-labs/pwa-bundle@"*"` is a separate manual step, worth doing since only `1.4.0-alpha1` was ever published.

## What users should do

Copy the controllers you use into your own application and register them there. They are plain Stimulus controllers with no dependency on the bundle, so nothing is lost in the move, and you get to drop the parts you never needed.

## Checks

- Behaviour verified against a Stimulus stub: a subclass overriding `connect()` without calling super still warns; the same identifier twice produces a single warning; the standalone controller and the helper both warn. 6 instantiations, 4 unique warnings.
- `node --check` on every modified file, `package.json` still parses
- PHP suite unaffected, 123 tests green