### PR TITLE
Let the application contribute caches to purge on install

### DIFF
--- a/src/ServiceWorkerRule/ClearCache.php
+++ b/src/ServiceWorkerRule/ClearCache.php
@@ -43,21 +43,29 @@ final class ClearCache implements ServiceWorkerRuleInterface, CanLogInterface
 
 /**************************************************** CACHE CLEAR ****************************************************/
 // The configuration is set to clear the cache on each install event
-// The following code will remove all the caches
+// Caches registered through registerCacheName() are removed. To also remove a cache
+// opened by the application, use registerClearCacheListener((names) => names.filter(...))
 
 DEBUG_COMMENT;
         }
 
         $declaration .= <<<CLEAR_CACHE
-registerInstallTask(() =>
-  caches.keys().then(keys =>
-    Promise.all(
-      keys
-        .filter(k => usedCacheNames.has(k))
-        .map(k => caches.delete(k))
-    )
-  )
-, 0);
+registerInstallTask(async () => {
+  const keys = await caches.keys();
+  const doomed = new Set(keys.filter(k => usedCacheNames.has(k)));
+
+  for (const task of clearCacheListeners) {
+    try {
+      for (const name of (await task(keys)) ?? []) {
+        doomed.add(name);
+      }
+    } catch (e) {
+      console.error('A clear cache listener failed', e);
+    }
+  }
+
+  await Promise.all([...doomed].map(k => caches.delete(k)));
+}, 0);
 
 CLEAR_CACHE;
 

--- a/src/ServiceWorkerRule/WorkboxHelpers.php
+++ b/src/ServiceWorkerRule/WorkboxHelpers.php
@@ -182,6 +182,14 @@ function registerCacheName(name) {
   return name;
 }
 
+// Called on install by the cache clearing rule, with every cache name currently stored.
+// Return the ones to delete. Caches opened by the application are unknown to
+// registerCacheName(), so this is how they get purged.
+const clearCacheListeners = [];
+function registerClearCacheListener(callback) {
+  clearCacheListeners.push(callback);
+}
+
 async function openBackgroundFetchDatabase() {
   return await self.idb.openDB('{$bgFetchDbName}', 1, {
     upgrade(db) {

--- a/tests/Unit/ServiceWorkerRule/ClearCacheTest.php
+++ b/tests/Unit/ServiceWorkerRule/ClearCacheTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Tests\Unit\ServiceWorkerRule;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\PwaBundle\Dto\ServiceWorker;
+use SpomkyLabs\PwaBundle\Dto\Workbox;
+use SpomkyLabs\PwaBundle\Service\ServiceWorkerBuilder;
+use SpomkyLabs\PwaBundle\ServiceWorkerRule\ClearCache;
+use SpomkyLabs\PwaBundle\ServiceWorkerRule\WorkboxHelpers;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+/**
+ * @internal
+ */
+final class ClearCacheTest extends TestCase
+{
+    #[Test]
+    public function itReturnsEmptyStringWhenWorkboxIsDisabled(): void
+    {
+        // Given
+        $workbox = new Workbox();
+        $workbox->enabled = false;
+
+        // When
+        $result = $this->createRule($workbox)
+            ->process();
+
+        // Then
+        static::assertSame('', $result);
+    }
+
+    #[Test]
+    public function itReturnsEmptyStringWhenClearCacheIsDisabled(): void
+    {
+        // Given
+        $workbox = new Workbox();
+        $workbox->enabled = true;
+        $workbox->clearCache = false;
+
+        // When
+        $result = $this->createRule($workbox)
+            ->process();
+
+        // Then
+        static::assertSame('', $result);
+    }
+
+    #[Test]
+    public function itPurgesTheCachesRegisteredByTheBundle(): void
+    {
+        // Given
+        $workbox = new Workbox();
+        $workbox->enabled = true;
+
+        // When
+        $result = $this->createRule($workbox)
+            ->process();
+
+        // Then
+        static::assertStringContainsString('const keys = await caches.keys();', $result);
+        static::assertStringContainsString('keys.filter(k => usedCacheNames.has(k))', $result);
+        static::assertStringContainsString('caches.delete(k)', $result);
+    }
+
+    /**
+     * Caches opened by the application are unknown to registerCacheName(), so they are
+     * contributed at install time instead of declared upfront.
+     */
+    #[Test]
+    public function itAsksTheApplicationWhichOtherCachesToPurge(): void
+    {
+        // Given
+        $workbox = new Workbox();
+        $workbox->enabled = true;
+
+        // When
+        $result = $this->createRule($workbox)
+            ->process();
+
+        // Then
+        static::assertStringContainsString('for (const task of clearCacheListeners) {', $result);
+        static::assertStringContainsString('for (const name of (await task(keys)) ?? []) {', $result);
+        static::assertStringContainsString('doomed.add(name);', $result);
+    }
+
+    /**
+     * A listener throwing must not take the install event down with it, nor stop the ones
+     * registered after it.
+     */
+    #[Test]
+    public function itSurvivesAListenerThatThrows(): void
+    {
+        // Given
+        $workbox = new Workbox();
+        $workbox->enabled = true;
+
+        // When
+        $result = $this->createRule($workbox)
+            ->process();
+
+        // Then
+        static::assertStringContainsString('} catch (e) {', $result);
+        static::assertStringContainsString("console.error('A clear cache listener failed', e);", $result);
+    }
+
+    #[Test]
+    public function itRunsFirstSoTheOtherInstallTasksSeeACleanState(): void
+    {
+        // Given
+        $workbox = new Workbox();
+        $workbox->enabled = true;
+
+        // When
+        $result = $this->createRule($workbox)
+            ->process();
+
+        // Then SkipWaiting is at 5, OfflineFallback at 10 and the cache strategies at 100
+        static::assertStringContainsString('}, 0);', $result);
+    }
+
+    /**
+     * The registry is declared by WorkboxHelpers, which runs at 1023 while this rule sits at
+     * the default priority, so the constant always exists by the time it is read.
+     */
+    #[Test]
+    public function itReliesOnARegistryDeclaredByTheHelpers(): void
+    {
+        // Given
+        $workbox = new Workbox();
+        $workbox->enabled = true;
+
+        // When
+        $helpers = $this->createHelpers($workbox)
+            ->process();
+
+        // Then
+        static::assertStringContainsString('const clearCacheListeners = [];', $helpers);
+        static::assertStringContainsString('function registerClearCacheListener(callback) {', $helpers);
+    }
+
+    #[Test]
+    public function itIncludesDebugCommentsWhenDebugModeIsEnabled(): void
+    {
+        // Given
+        $workbox = new Workbox();
+        $workbox->enabled = true;
+
+        // When
+        $result = $this->createRule($workbox)
+            ->process(debug: true);
+
+        // Then
+        static::assertStringContainsString('CACHE CLEAR', $result);
+        static::assertStringContainsString('registerClearCacheListener', $result);
+        static::assertStringContainsString('END CACHE CLEAR', $result);
+    }
+
+    private function createRule(Workbox $workbox): ClearCache
+    {
+        return new ClearCache($this->createBuilder($workbox));
+    }
+
+    private function createHelpers(Workbox $workbox): WorkboxHelpers
+    {
+        return new WorkboxHelpers($this->createBuilder($workbox));
+    }
+
+    private function createBuilder(Workbox $workbox): ServiceWorkerBuilder
+    {
+        $serviceWorker = new ServiceWorker();
+        $serviceWorker->workbox = $workbox;
+
+        $denormalizer = $this->createMock(DenormalizerInterface::class);
+        $denormalizer
+            ->method('denormalize')
+            ->willReturn($serviceWorker);
+
+        return new ServiceWorkerBuilder($denormalizer, []);
+    }
+}


### PR DESCRIPTION
## The problem

`ClearCache` deletes only the caches registered through `registerCacheName()`:

```js
keys.filter(k => usedCacheNames.has(k)).map(k => caches.delete(k))
```

That covers the strategies the bundle generates and nothing else. A cache the application opens itself with `caches.open()` from its own `serviceworker.src` survives every install, **silently**: nothing in the configuration or the documentation says the purge is scoped to a registry, and `clear_cache: true` reads like "clear the cache".

It is easy to hit. An application overriding the default image cache with its own `CacheFirst` strategy, `cacheName: 'images'` written by hand rather than through `registerCacheName('images')`, never gets that cache purged.

## What changes

A new helper, `registerClearCacheListener()`. The callback receives every cache name currently stored and returns the ones to delete:

```js
// in your own serviceworker.src
registerClearCacheListener((names) =>
    names.filter((n) => n.startsWith('my-app-') && n !== 'my-app-v3')
);
```

A callback rather than a list of names in the configuration, because the interesting cases are dynamic: versioned caches where the current one must survive, prefix matching, anything computed at runtime. A static YAML list cannot express any of that.

It also means **no configuration node, no DTO change, no deprecation, and no BC break of any kind**. `Workbox::$clearCache` stays a `bool`.

The registry is declared by `WorkboxHelpers` (priority 1023) and read by `ClearCache` (default priority), so the constant always exists by the time it is used. The application source is appended last by the compiler but runs at parse time, well before `install` fires, so listeners registered there are always seen.

Callbacks may be sync or async, and are individually guarded: one throwing is logged and does not stop the others, nor take the install event down with it.

## Behaviour

Verified by running the generated code against a service worker stub, not just by asserting on strings:

| Cache | Registered by | Result |
|---|---|---|
| `assets`, `fonts`, `app-pages` | `registerCacheName()` | deleted |
| `my-app-v2` | listener predicate | deleted |
| `my-app-v3` | listener predicate keeps it | **kept** |
| `images` | async listener | deleted |
| `unrelated` | nobody | **kept** |

A third listener throwing on purpose was caught and logged without affecting the others.

## Checks

- 131 tests, 8 added in the new `ClearCacheTest`
- ECS, Deptrac and PHPStan clean, no new error

## Note for the merge order

This touches `WorkboxHelpers`, which #455 rewrites heavily. Whichever lands first, the other needs a rebase; the conflict is confined to the heredoc around `registerCacheName`.

## Follow-up

The documentation should state plainly that `registerCacheName()` is what makes a cache eligible for the purge, and document the new helper. That belongs in `cache-cleaning.md` and `custom-service-worker-rule.md`, in the documentation repository.