### PR TITLE
Replace the debug comment heredocs with a ScriptSection builder

### DIFF
--- a/src/CachingStrategy/WorkboxCacheStrategy.php
+++ b/src/CachingStrategy/WorkboxCacheStrategy.php
@@ -11,9 +11,11 @@ use const JSON_THROW_ON_ERROR;
 use const JSON_UNESCAPED_SLASHES;
 use const JSON_UNESCAPED_UNICODE;
 use const PHP_EOL;
+use SpomkyLabs\PwaBundle\Service\ScriptSection;
 use SpomkyLabs\PwaBundle\WorkboxPlugin\CachePluginInterface;
 use SpomkyLabs\PwaBundle\WorkboxPlugin\HasBodyInterface;
 use function sprintf;
+use function var_export;
 
 final class WorkboxCacheStrategy implements CacheStrategyInterface
 {
@@ -147,28 +149,21 @@ final class WorkboxCacheStrategy implements CacheStrategyInterface
 
         $method = $this->method !== null ? ",'{$this->method}'" : '';
 
-        $declaration = '';
-        if ($debug) {
-            $matchCallbackComment = str_replace(['*/', '/*'], ['*\\/', '/\\*'], $this->matchCallback);
-            $declaration .= <<<DEBUG_STATEMENT
-
-
-/**************************************************** CACHE STRATEGY ****************************************************/
-// Strategy: {$this->strategy}
-/* Match: {$matchCallbackComment} */
-// Cache Name: {$this->getName()}
-// Enabled: {$this->enabled}
-// Needs Workbox: {$this->needsWorkbox()}
-// Method: {$this->method}
-
-// 1. Creation of the Workbox Cache Strategy object
-// 2. Register the route with the Workbox Router
-// 3. Add the assets to the cache when the service worker is installed
-
-DEBUG_STATEMENT;
-        }
-
-        $declaration .= <<<ROUTE_REGISTRATION
+        $section = ScriptSection::create('CACHE STRATEGY', $debug)
+            ->comment(
+                sprintf('Strategy: %s', $this->strategy),
+                sprintf('Match: %s', $this->matchCallback),
+                sprintf('Cache Name: %s', $this->getName()),
+                sprintf('Enabled: %s', var_export($this->enabled, true)),
+                sprintf('Needs Workbox: %s', var_export($this->needsWorkbox(), true)),
+                sprintf('Method: %s', $this->method)
+            )
+            ->comment(
+                '1. Creation of the Workbox Cache Strategy object',
+                '2. Register the route with the Workbox Router',
+                '3. Add the assets to the cache when the service worker is installed'
+            )
+            ->code(<<<ROUTE_REGISTRATION
 {$pluginBody}
 
 const {$cacheObjectName} = new workbox.strategies.{$this->strategy}({
@@ -176,24 +171,17 @@ const {$cacheObjectName} = new workbox.strategies.{$this->strategy}({
 });
 workbox.routing.registerRoute({$this->matchCallback},{$cacheObjectName}{$method});
 
-ROUTE_REGISTRATION;
+ROUTE_REGISTRATION);
 
         if ($this->preloadUrls !== []) {
             $urls = json_encode($this->preloadUrls, $jsonOptions);
-            $declaration .= <<<ASSET_CACHE_RULE_PRELOAD
+            $section->code(<<<ASSET_CACHE_RULE_PRELOAD
 registerInstallTask((event) => precacheResources({$cacheObjectName}, {$urls}, event));
 
-ASSET_CACHE_RULE_PRELOAD;
+ASSET_CACHE_RULE_PRELOAD);
         }
 
-        if ($debug) {
-            $declaration .= <<<DEBUG_STATEMENT
-/**************************************************** END CACHE STRATEGY ****************************************************/
-
-
-
-DEBUG_STATEMENT;
-        }
+        $declaration = $section->render();
 
         return $debug ? $declaration : trim($declaration);
     }

--- a/src/Service/ScriptSection.php
+++ b/src/Service/ScriptSection.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Service;
+
+use function sprintf;
+use Stringable;
+
+/**
+ * Assembles a named block of the generated service worker script.
+ *
+ * The section title and the comments are only rendered when debug mode is enabled; otherwise the
+ * generated code is returned untouched. Callers can therefore document what they generate without
+ * surrounding every explanation with a conditional and a heredoc.
+ */
+final class ScriptSection implements Stringable
+{
+    private const EOL = "\n";
+
+    private const BANNER_FILLER = '****************************************************';
+
+    /**
+     * @var list<string>
+     */
+    private array $body = [];
+
+    private function __construct(
+        private readonly string $title,
+        private readonly bool $debug,
+    ) {
+    }
+
+    public static function create(string $title, bool $debug): self
+    {
+        return new self($title, $debug);
+    }
+
+    /**
+     * Adds a comment block, rendered in debug mode only. Multi-line values are split so that every
+     * single line gets its own comment marker.
+     */
+    public function comment(string $line, string ...$lines): self
+    {
+        if ($this->debug === false) {
+            return $this;
+        }
+
+        $block = '';
+        foreach ([$line, ...$lines] as $entry) {
+            foreach (explode(self::EOL, $entry) as $row) {
+                $block .= rtrim('// ' . $row) . self::EOL;
+            }
+        }
+        $this->body[] = $block . self::EOL;
+
+        return $this;
+    }
+
+    /**
+     * Adds a piece of generated code, always rendered.
+     */
+    public function code(string $code): self
+    {
+        $this->body[] = $code;
+
+        return $this;
+    }
+
+    public function render(): string
+    {
+        $body = implode('', $this->body);
+        if ($this->debug === false) {
+            return $body;
+        }
+
+        return self::EOL . self::EOL . $this->banner($this->title) . self::EOL
+            . $body
+            . $this->banner('END ' . $this->title) . str_repeat(self::EOL, 4);
+    }
+
+    public function __toString(): string
+    {
+        return $this->render();
+    }
+
+    private function banner(string $title): string
+    {
+        return sprintf('/%s %s %s/', self::BANNER_FILLER, $title, self::BANNER_FILLER);
+    }
+}

--- a/src/ServiceWorkerRule/ClearCache.php
+++ b/src/ServiceWorkerRule/ClearCache.php
@@ -8,6 +8,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use SpomkyLabs\PwaBundle\Dto\Workbox;
 use SpomkyLabs\PwaBundle\Service\CanLogInterface;
+use SpomkyLabs\PwaBundle\Service\ScriptSection;
 use SpomkyLabs\PwaBundle\Service\ServiceWorkerBuilder;
 
 final class ClearCache implements ServiceWorkerRuleInterface, CanLogInterface
@@ -36,19 +37,7 @@ final class ClearCache implements ServiceWorkerRuleInterface, CanLogInterface
             return '';
         }
 
-        $declaration = '';
-        if ($debug) {
-            $declaration .= <<<DEBUG_COMMENT
-
-
-/**************************************************** CACHE CLEAR ****************************************************/
-// The configuration is set to clear the cache on each install event
-// The following code will remove all the caches
-
-DEBUG_COMMENT;
-        }
-
-        $declaration .= <<<CLEAR_CACHE
+        $clearCache = <<<'CLEAR_CACHE'
 registerInstallTask(() =>
   caches.keys().then(keys =>
     Promise.all(
@@ -61,15 +50,14 @@ registerInstallTask(() =>
 
 CLEAR_CACHE;
 
-        if ($debug) {
-            $declaration .= <<<DEBUG_COMMENT
-/**************************************************** END CACHE CLEAR ****************************************************/
+        $declaration = ScriptSection::create('CACHE CLEAR', $debug)
+            ->comment(
+                'The configuration is set to clear the cache on each install event',
+                'The following code will remove all the caches'
+            )
+            ->code($clearCache)
+            ->render();
 
-
-
-
-DEBUG_COMMENT;
-        }
         $this->logger->debug('Cache clear rule added.', [
             'declaration' => $declaration,
         ]);

--- a/src/ServiceWorkerRule/NavigationPreload.php
+++ b/src/ServiceWorkerRule/NavigationPreload.php
@@ -8,6 +8,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use SpomkyLabs\PwaBundle\Dto\Workbox;
 use SpomkyLabs\PwaBundle\Service\CanLogInterface;
+use SpomkyLabs\PwaBundle\Service\ScriptSection;
 use SpomkyLabs\PwaBundle\Service\ServiceWorkerBuilder;
 use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 
@@ -38,33 +39,14 @@ final class NavigationPreload implements ServiceWorkerRuleInterface, CanLogInter
             return '';
         }
 
-        $declaration = '';
-        if ($debug) {
-            $declaration .= <<<DEBUG_COMMENT
-
-
-/**************************************************** NAVIGATION PRELOAD ****************************************************/
-// Navigation Preload is enabled
-// This speeds up navigation requests by making the network request in parallel with service worker boot-up
-// See: https://developer.chrome.com/docs/workbox/modules/workbox-navigation-preload/
-
-DEBUG_COMMENT;
-        }
-
-        $declaration .= <<<NAVIGATION_PRELOAD
-workbox.navigationPreload.enable();
-
-NAVIGATION_PRELOAD;
-
-        if ($debug) {
-            $declaration .= <<<DEBUG_COMMENT
-/**************************************************** END NAVIGATION PRELOAD ****************************************************/
-
-
-
-
-DEBUG_COMMENT;
-        }
+        $declaration = ScriptSection::create('NAVIGATION PRELOAD', $debug)
+            ->comment(
+                'Navigation Preload is enabled',
+                'This speeds up navigation requests by making the network request in parallel with service worker boot-up',
+                'See: https://developer.chrome.com/docs/workbox/modules/workbox-navigation-preload/'
+            )
+            ->code("workbox.navigationPreload.enable();\n")
+            ->render();
 
         $this->logger->debug('Navigation preload rule applied.', [
             'declaration' => $declaration,

--- a/src/ServiceWorkerRule/OfflineFallback.php
+++ b/src/ServiceWorkerRule/OfflineFallback.php
@@ -12,6 +12,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use SpomkyLabs\PwaBundle\Dto\Workbox;
 use SpomkyLabs\PwaBundle\Service\CanLogInterface;
+use SpomkyLabs\PwaBundle\Service\ScriptSection;
 use SpomkyLabs\PwaBundle\Service\ServiceWorkerBuilder;
 use Symfony\Component\Serializer\Encoder\JsonEncode;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
@@ -52,18 +53,7 @@ final class OfflineFallback implements ServiceWorkerRuleInterface, CanLogInterfa
         $urls = $this->serializer->serialize(array_values($options), 'json', $this->serializerOptions($debug));
         $fallbacks = $this->serializer->serialize($options, 'json', $this->serializerOptions($debug));
 
-        $declaration = '';
-        if ($debug) {
-            $declaration .= <<<DEBUG_COMMENT
-
-
-/**************************************************** OFFLINE FALLBACK ****************************************************/
-// The configuration is set to provide offline fallbacks
-
-DEBUG_COMMENT;
-        }
-
-        $declaration .= <<<OFFLINE_FALLBACK_STRATEGY
+        $offlineFallback = <<<OFFLINE_FALLBACK_STRATEGY
 workbox.routing.setDefaultHandler(new workbox.strategies.NetworkOnly());
 registerInstallTask(() => {
   return openCache(registerCacheName('{$cacheName}')).then(cache =>
@@ -90,15 +80,11 @@ workbox.routing.setCatchHandler(async ({ request }) => {
 
 OFFLINE_FALLBACK_STRATEGY;
 
-        if ($debug) {
-            $declaration .= <<<DEBUG_COMMENT
-/**************************************************** END OFFLINE FALLBACK ****************************************************/
+        $declaration = ScriptSection::create('OFFLINE FALLBACK', $debug)
+            ->comment('The configuration is set to provide offline fallbacks')
+            ->code($offlineFallback)
+            ->render();
 
-
-
-
-DEBUG_COMMENT;
-        }
         $this->logger->debug('Offline fallback rule added.', [
             'declaration' => $declaration,
         ]);

--- a/src/ServiceWorkerRule/SkipWaiting.php
+++ b/src/ServiceWorkerRule/SkipWaiting.php
@@ -8,6 +8,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use SpomkyLabs\PwaBundle\Dto\ServiceWorker;
 use SpomkyLabs\PwaBundle\Service\CanLogInterface;
+use SpomkyLabs\PwaBundle\Service\ScriptSection;
 use SpomkyLabs\PwaBundle\Service\ServiceWorkerBuilder;
 
 final class SkipWaiting implements ServiceWorkerRuleInterface, CanLogInterface
@@ -29,33 +30,19 @@ final class SkipWaiting implements ServiceWorkerRuleInterface, CanLogInterface
             return '';
         }
 
-        $declaration = '';
-        if ($debug) {
-            $declaration .= <<<DEBUG_COMMENT
-
-
-/**************************************************** SKIP WAITING ****************************************************/
-// The configuration is set to skip waiting on each install event
-
-DEBUG_COMMENT;
-        }
-
-        $declaration .= <<<SKIP_WAITING
+        $skipWaiting = <<<'SKIP_WAITING'
 registerInstallTask(() => self.skipWaiting(), 5);
 self.addEventListener("activate", function (event) {
   event.waitUntil(self.clients.claim());
 });
 
 SKIP_WAITING;
-        if ($debug) {
-            $declaration .= <<<DEBUG_COMMENT
-/**************************************************** END SKIP WAITING ****************************************************/
 
+        $declaration = ScriptSection::create('SKIP WAITING', $debug)
+            ->comment('The configuration is set to skip waiting on each install event')
+            ->code($skipWaiting)
+            ->render();
 
-
-
-DEBUG_COMMENT;
-        }
         $this->logger->debug('Skip waiting rule applied.', [
             'declaration' => $declaration,
         ]);

--- a/src/ServiceWorkerRule/WindowsWidgets.php
+++ b/src/ServiceWorkerRule/WindowsWidgets.php
@@ -14,6 +14,7 @@ use Psr\Log\NullLogger;
 use SpomkyLabs\PwaBundle\Dto\Manifest;
 use SpomkyLabs\PwaBundle\Service\CanLogInterface;
 use SpomkyLabs\PwaBundle\Service\ManifestBuilder;
+use SpomkyLabs\PwaBundle\Service\ScriptSection;
 use Symfony\Component\Serializer\Encoder\JsonEncode;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -44,19 +45,7 @@ final class WindowsWidgets implements ServiceWorkerRuleInterface, CanLogInterfac
             return '';
         }
         $data = $this->serializer->serialize($tags, 'json', $this->serializerOptions($debug));
-        $declaration = '';
-        if ($debug) {
-            $declaration .= <<<DEBUG_COMMENT
-
-
-/**************************************************** END WINDOWS WIDGETS ****************************************************/
-// The following code will manage the installation and uninstallation of widgets
-// NOTE: this feature is experimental and may not work as expected
-
-DEBUG_COMMENT;
-        }
-
-        $declaration .= <<<OFFLINE_FALLBACK_STRATEGY
+        $windowsWidgets = <<<WINDOWS_WIDGETS
 self.addEventListener("widgetinstall", event => {
     event.waitUntil(renderWidget(event.widget));
 });
@@ -115,16 +104,16 @@ async function updateWidgets() {
     }
 }
 
-OFFLINE_FALLBACK_STRATEGY;
-        if ($debug) {
-            $declaration .= <<<DEBUG_COMMENT
-/**************************************************** END WINDOWS WIDGETS ****************************************************/
+WINDOWS_WIDGETS;
 
+        $declaration = ScriptSection::create('WINDOWS WIDGETS', $debug)
+            ->comment(
+                'The following code will manage the installation and uninstallation of widgets',
+                'NOTE: this feature is experimental and may not work as expected'
+            )
+            ->code($windowsWidgets)
+            ->render();
 
-
-
-DEBUG_COMMENT;
-        }
         $this->logger->debug('Windows widgets rule added.', [
             'declaration' => $declaration,
         ]);

--- a/src/ServiceWorkerRule/WorkboxImport.php
+++ b/src/ServiceWorkerRule/WorkboxImport.php
@@ -10,6 +10,7 @@ use Psr\Log\NullLogger;
 use SpomkyLabs\PwaBundle\Dto\Workbox;
 use SpomkyLabs\PwaBundle\Service\BasePathResolver;
 use SpomkyLabs\PwaBundle\Service\CanLogInterface;
+use SpomkyLabs\PwaBundle\Service\ScriptSection;
 use SpomkyLabs\PwaBundle\Service\ServiceWorkerBuilder;
 use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 
@@ -35,47 +36,31 @@ final class WorkboxImport implements ServiceWorkerRuleInterface, CanLogInterface
             $this->logger->debug('Workbox is disabled. The rule will not be applied.');
             return '';
         }
-        $declaration = '';
-        if ($debug) {
-            $declaration .= <<<DEBUG_COMMENT
+        $section = ScriptSection::create('WORKBOX IMPORT', $debug)
+            ->comment(
+                'The configuration is set to use Workbox',
+                'The following code will import Workbox from CDN or public URL'
+            );
 
-
-/**************************************************** WORKBOX IMPORT ****************************************************/
-// The configuration is set to use Workbox
-// The following code will import Workbox from CDN or public URL
-
-DEBUG_COMMENT;
-        }
         if ($this->workbox->config->useCDN) {
-            if ($debug) {
-                $declaration .= <<<DEBUG_COMMENT
-// Import from CDN
-
-
-DEBUG_COMMENT;
-            }
-            $declaration .= <<<IMPORT_CDN_STRATEGY
+            $section->comment('Import from CDN')
+                ->code(<<<IMPORT_CDN_STRATEGY
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/{$this->workbox->config->version}/workbox-sw.js');
 importScripts('https://cdn.jsdelivr.net/npm/idb@8/build/umd.js');
-IMPORT_CDN_STRATEGY;
+
+IMPORT_CDN_STRATEGY);
         } else {
             $workboxPublicUrl = $this->basePathResolver->prefix(
                 '/' . trim($this->workbox->config->workboxPublicUrl, '/')
             );
             $idbPublicUrl = $this->basePathResolver->prefix('/' . trim($this->workbox->indexDBPublicUrl, '/'));
-            if ($debug) {
-                $declaration .= <<<DEBUG_COMMENT
-// Import from public URL
-
-
-DEBUG_COMMENT;
-            }
-            $declaration .= <<<IMPORT_CDN_STRATEGY
+            $section->comment('Import from public URL')
+                ->code(<<<IMPORT_PUBLIC_URL_STRATEGY
 importScripts('{$workboxPublicUrl}/workbox-sw.js');
 importScripts('{$idbPublicUrl}/umd.js');
 workbox.setConfig({modulePathPrefix: '{$workboxPublicUrl}'});
 
-IMPORT_CDN_STRATEGY;
+IMPORT_PUBLIC_URL_STRATEGY);
         }
 
         // Add workbox configuration
@@ -86,24 +71,11 @@ IMPORT_CDN_STRATEGY;
 
         if ($configOptions !== []) {
             $configJson = json_encode($configOptions, JSON_UNESCAPED_SLASHES);
-            if ($debug) {
-                $declaration .= <<<DEBUG_COMMENT
-// Additional Workbox configuration
-
-DEBUG_COMMENT;
-            }
-            $declaration .= "workbox.setConfig({$configJson});\n";
+            $section->comment('Additional Workbox configuration')
+                ->code("workbox.setConfig({$configJson});\n");
         }
 
-        if ($debug) {
-            $declaration .= <<<DEBUG_COMMENT
-/**************************************************** END WORKBOX IMPORT ****************************************************/
-
-
-
-
-DEBUG_COMMENT;
-        }
+        $declaration = $section->render();
         $this->logger->debug('Workbox import rule added.', [
             'declaration' => $declaration,
         ]);

--- a/tests/Unit/Service/ScriptSectionTest.php
+++ b/tests/Unit/Service/ScriptSectionTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Tests\Unit\Service;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\PwaBundle\Service\ScriptSection;
+
+/**
+ * @internal
+ */
+final class ScriptSectionTest extends TestCase
+{
+    #[Test]
+    public function itOnlyRendersTheCodeWhenDebugIsDisabled(): void
+    {
+        // Given
+        $section = ScriptSection::create('CACHE CLEAR', false)
+            ->comment('This comment is only for the developers')
+            ->code("caches.delete('foo');\n");
+
+        // When
+        $result = $section->render();
+
+        // Then
+        static::assertSame("caches.delete('foo');\n", $result);
+    }
+
+    #[Test]
+    public function itSurroundsTheCodeWithBannersWhenDebugIsEnabled(): void
+    {
+        // Given
+        $section = ScriptSection::create('CACHE CLEAR', true)
+            ->code("caches.delete('foo');\n");
+
+        // When
+        $result = $section->render();
+
+        // Then
+        static::assertStringStartsWith("\n\n/*", $result);
+        static::assertStringContainsString(' CACHE CLEAR ', $result);
+        static::assertStringContainsString(' END CACHE CLEAR ', $result);
+        static::assertStringContainsString("caches.delete('foo');\n", $result);
+        static::assertStringEndsWith("\n\n\n\n", $result);
+    }
+
+    #[Test]
+    public function itRendersEveryCommentLineWithItsOwnMarker(): void
+    {
+        // Given
+        $section = ScriptSection::create('CACHE STRATEGY', true)
+            ->comment('First line', "Second line\nover two rows")
+            ->code('');
+
+        // When
+        $result = $section->render();
+
+        // Then
+        static::assertStringContainsString("// First line\n// Second line\n// over two rows\n\n", $result);
+    }
+
+    #[Test]
+    public function itKeepsTheCodeInTheOrderItWasAdded(): void
+    {
+        // Given
+        $section = ScriptSection::create('WORKBOX IMPORT', false)
+            ->code("first();\n")
+            ->comment('Ignored')
+            ->code("second();\n");
+
+        // When
+        $result = $section->render();
+
+        // Then
+        static::assertSame("first();\nsecond();\n", $result);
+    }
+
+    #[Test]
+    public function itCanBeCastToAString(): void
+    {
+        // Given
+        $section = ScriptSection::create('SKIP WAITING', false)
+            ->code("self.skipWaiting();\n");
+
+        // Then
+        static::assertSame($section->render(), (string) $section);
+    }
+}


### PR DESCRIPTION
## Problem

Every service worker rule — and `WorkboxCacheStrategy` — wrapped its generated JavaScript in blocks like this:

```php
$declaration = '';
if ($debug === true) {
    $declaration .= <<<DEBUG_COMMENT


/**************************************************** CACHE CLEAR ****************************************************/
// The configuration is set to clear the cache on each install event
// The following code will remove all the caches

DEBUG_COMMENT;
}

$declaration .= <<<CLEAR_CACHE
...
CLEAR_CACHE;

if ($debug === true) {
    $declaration .= <<<DEBUG_COMMENT
/**************************************************** END CACHE CLEAR ****************************************************/




DEBUG_COMMENT;
}
```

The banners and their explanations are genuinely useful in the generated `sw.js`, but they buried the code generation under a dozen lines of noise per rule, and the exact number of trailing blank lines had to be repeated by hand everywhere.

## Solution

A new `SpomkyLabs\PwaBundle\Service\ScriptSection` owns that formatting. A section is created with a title and the debug flag; comments and code are appended in order; banners and comments are only rendered when debug mode is on. The same rule now reads:

```php
$declaration = ScriptSection::create('CACHE CLEAR', $debug)
    ->comment(
        'The configuration is set to clear the cache on each install event',
        'The following code will remove all the caches'
    )
    ->code($clearCache)
    ->render();
```

Each rule keeps a single heredoc for the JavaScript it generates — that one is legitimate — and describes it with `->comment(...)`.

## Debug output

The generated service worker is unchanged apart from the fixes below and one extra blank line after each comment block (the spacing is now uniform across sections).

Three defects disappear along the way:

* the Windows widgets section opened with `END WINDOWS WIDGETS`;
* the Workbox CDN import glued `importScripts('.../umd.js');` to whatever followed it, because its heredoc had no trailing newline — this one also affected non-debug output;
* the cache strategy match callback was rendered inside a `/* */` block, which needed `*/` escaping and broke on multi-line callbacks. Every comment line now carries its own `//` marker, so no escaping is needed.

`Enabled` and `Needs Workbox` are also reported as `true`/`false` instead of the `1`/empty string that string interpolation produced.

## Checks

* `ecs`, `rector --dry-run`, `deptrac` and `phpstan` are clean (the only PHPStan error left is the pre-existing `imagedestroy()` deprecation on PHP 8.5, untouched here).
* The test suite passes; the two `ConfigurationTest` failures also fail on `1.5.x` without this change.
* `ScriptSectionTest` covers the new class, and the debug output was diffed rule by rule against the previous implementation.