### PR TITLE
Silence the PHP 8.5 deprecations and align the two image processors

### DIFF
--- a/.ci-tools/rector.php
+++ b/.ci-tools/rector.php
@@ -7,6 +7,7 @@ use Rector\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector;
 use Rector\Doctrine\Set\DoctrineSetList;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
@@ -47,6 +48,10 @@ $builder->withSkip([
     // The $requests argument of RequestStack::__construct() only exists from Symfony 7.2 on, while
     // composer.json allows ^7.0. Applying this would break the --prefer-lowest test job.
     PushRequestToRequestStackConstructorRector::class,
+    // Rector sees the PHPUnit composer resolves, currently 13, while the test job runs the phpunit-11
+    // the phpqa image ships. Renaming an assertion to its later spelling — expectExceptionMessage() to
+    // expectExceptionMessageIsOrContains(), added in PHPUnit 12 — passes here and fails there.
+    RenameMethodRector::class => [__DIR__ . '/../tests'],
 ]);
 $builder->withParallel();
 $builder->withImportNames();

--- a/src/ImageProcessor/Color.php
+++ b/src/ImageProcessor/Color.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\ImageProcessor;
+
+use InvalidArgumentException;
+use function mb_str_split;
+use function mb_strlen;
+use function mb_strtolower;
+use function sprintf;
+
+/**
+ * A colour taken from the bundle configuration, resolved to the channels the GD extension expects.
+ *
+ * GD only knows about integer channels, so every notation the configuration documents — a CSS colour name or an
+ * hexadecimal triplet — has to be resolved here first. Feeding hexdec() with whatever the configuration holds is not an
+ * option: it emits a deprecation for every character that is not hexadecimal, so "red" both warns and resolves to a
+ * meaningless dark colour.
+ *
+ * @internal
+ */
+final readonly class Color
+{
+    /**
+     * The CSS Color Module Level 4 named colours.
+     *
+     * ImageMagick resolves nearly the same table, with three exceptions kept on the CSS side here: it reads "gray" as
+     * #7E7E7E and "grey" as the X11 #BEBEBE instead of #808080, and it does not know "rebeccapurple" at all.
+     *
+     * @var array<string, string>
+     */
+    private const NAMED_COLORS = [
+        'aliceblue' => 'f0f8ff',
+        'antiquewhite' => 'faebd7',
+        'aqua' => '00ffff',
+        'aquamarine' => '7fffd4',
+        'azure' => 'f0ffff',
+        'beige' => 'f5f5dc',
+        'bisque' => 'ffe4c4',
+        'black' => '000000',
+        'blanchedalmond' => 'ffebcd',
+        'blue' => '0000ff',
+        'blueviolet' => '8a2be2',
+        'brown' => 'a52a2a',
+        'burlywood' => 'deb887',
+        'cadetblue' => '5f9ea0',
+        'chartreuse' => '7fff00',
+        'chocolate' => 'd2691e',
+        'coral' => 'ff7f50',
+        'cornflowerblue' => '6495ed',
+        'cornsilk' => 'fff8dc',
+        'crimson' => 'dc143c',
+        'cyan' => '00ffff',
+        'darkblue' => '00008b',
+        'darkcyan' => '008b8b',
+        'darkgoldenrod' => 'b8860b',
+        'darkgray' => 'a9a9a9',
+        'darkgreen' => '006400',
+        'darkgrey' => 'a9a9a9',
+        'darkkhaki' => 'bdb76b',
+        'darkmagenta' => '8b008b',
+        'darkolivegreen' => '556b2f',
+        'darkorange' => 'ff8c00',
+        'darkorchid' => '9932cc',
+        'darkred' => '8b0000',
+        'darksalmon' => 'e9967a',
+        'darkseagreen' => '8fbc8f',
+        'darkslateblue' => '483d8b',
+        'darkslategray' => '2f4f4f',
+        'darkslategrey' => '2f4f4f',
+        'darkturquoise' => '00ced1',
+        'darkviolet' => '9400d3',
+        'deeppink' => 'ff1493',
+        'deepskyblue' => '00bfff',
+        'dimgray' => '696969',
+        'dimgrey' => '696969',
+        'dodgerblue' => '1e90ff',
+        'firebrick' => 'b22222',
+        'floralwhite' => 'fffaf0',
+        'forestgreen' => '228b22',
+        'fuchsia' => 'ff00ff',
+        'gainsboro' => 'dcdcdc',
+        'ghostwhite' => 'f8f8ff',
+        'gold' => 'ffd700',
+        'goldenrod' => 'daa520',
+        'gray' => '808080',
+        'green' => '008000',
+        'greenyellow' => 'adff2f',
+        'grey' => '808080',
+        'honeydew' => 'f0fff0',
+        'hotpink' => 'ff69b4',
+        'indianred' => 'cd5c5c',
+        'indigo' => '4b0082',
+        'ivory' => 'fffff0',
+        'khaki' => 'f0e68c',
+        'lavender' => 'e6e6fa',
+        'lavenderblush' => 'fff0f5',
+        'lawngreen' => '7cfc00',
+        'lemonchiffon' => 'fffacd',
+        'lightblue' => 'add8e6',
+        'lightcoral' => 'f08080',
+        'lightcyan' => 'e0ffff',
+        'lightgoldenrodyellow' => 'fafad2',
+        'lightgray' => 'd3d3d3',
+        'lightgreen' => '90ee90',
+        'lightgrey' => 'd3d3d3',
+        'lightpink' => 'ffb6c1',
+        'lightsalmon' => 'ffa07a',
+        'lightseagreen' => '20b2aa',
+        'lightskyblue' => '87cefa',
+        'lightslategray' => '778899',
+        'lightslategrey' => '778899',
+        'lightsteelblue' => 'b0c4de',
+        'lightyellow' => 'ffffe0',
+        'lime' => '00ff00',
+        'limegreen' => '32cd32',
+        'linen' => 'faf0e6',
+        'magenta' => 'ff00ff',
+        'maroon' => '800000',
+        'mediumaquamarine' => '66cdaa',
+        'mediumblue' => '0000cd',
+        'mediumorchid' => 'ba55d3',
+        'mediumpurple' => '9370db',
+        'mediumseagreen' => '3cb371',
+        'mediumslateblue' => '7b68ee',
+        'mediumspringgreen' => '00fa9a',
+        'mediumturquoise' => '48d1cc',
+        'mediumvioletred' => 'c71585',
+        'midnightblue' => '191970',
+        'mintcream' => 'f5fffa',
+        'mistyrose' => 'ffe4e1',
+        'moccasin' => 'ffe4b5',
+        'navajowhite' => 'ffdead',
+        'navy' => '000080',
+        'oldlace' => 'fdf5e6',
+        'olive' => '808000',
+        'olivedrab' => '6b8e23',
+        'orange' => 'ffa500',
+        'orangered' => 'ff4500',
+        'orchid' => 'da70d6',
+        'palegoldenrod' => 'eee8aa',
+        'palegreen' => '98fb98',
+        'paleturquoise' => 'afeeee',
+        'palevioletred' => 'db7093',
+        'papayawhip' => 'ffefd5',
+        'peachpuff' => 'ffdab9',
+        'peru' => 'cd853f',
+        'pink' => 'ffc0cb',
+        'plum' => 'dda0dd',
+        'powderblue' => 'b0e0e6',
+        'purple' => '800080',
+        'rebeccapurple' => '663399',
+        'red' => 'ff0000',
+        'rosybrown' => 'bc8f8f',
+        'royalblue' => '4169e1',
+        'saddlebrown' => '8b4513',
+        'salmon' => 'fa8072',
+        'sandybrown' => 'f4a460',
+        'seagreen' => '2e8b57',
+        'seashell' => 'fff5ee',
+        'sienna' => 'a0522d',
+        'silver' => 'c0c0c0',
+        'skyblue' => '87ceeb',
+        'slateblue' => '6a5acd',
+        'slategray' => '708090',
+        'slategrey' => '708090',
+        'snow' => 'fffafa',
+        'springgreen' => '00ff7f',
+        'steelblue' => '4682b4',
+        'tan' => 'd2b48c',
+        'teal' => '008080',
+        'thistle' => 'd8bfd8',
+        'tomato' => 'ff6347',
+        'turquoise' => '40e0d0',
+        'violet' => 'ee82ee',
+        'wheat' => 'f5deb3',
+        'white' => 'ffffff',
+        'whitesmoke' => 'f5f5f5',
+        'yellow' => 'ffff00',
+        'yellowgreen' => '9acd32',
+    ];
+
+    /**
+     * @param int<0, 255> $red
+     * @param int<0, 255> $green
+     * @param int<0, 255> $blue
+     * @param int<0, 127> $alpha On the GD scale: 0 is fully opaque, 127 fully transparent.
+     */
+    private function __construct(
+        public int $red,
+        public int $green,
+        public int $blue,
+        public int $alpha,
+    ) {
+    }
+
+    /**
+     * Accepts a CSS colour name, the "transparent" keyword, or an hexadecimal notation with 3, 4, 6 or 8 digits and an
+     * optional leading "#".
+     */
+    public static function fromString(string $color): self
+    {
+        $normalized = mb_strtolower(trim($color));
+        if ($normalized === 'transparent') {
+            return new self(0, 0, 0, 127);
+        }
+        $normalized = self::NAMED_COLORS[$normalized] ?? $normalized;
+
+        if (preg_match('/^#?([0-9a-f]{3,8})$/', $normalized, $matches) !== 1) {
+            throw self::unsupported($color);
+        }
+        $hex = $matches[1];
+        $channels = match (mb_strlen($hex)) {
+            // The short notations repeat every digit: "#1a2" is "#11aa22".
+            3, 4 => array_map(static fn (string $digit): string => $digit . $digit, mb_str_split($hex)),
+            6, 8 => mb_str_split($hex, 2),
+            default => throw self::unsupported($color),
+        };
+
+        return new self(
+            self::channel($channels[0]),
+            self::channel($channels[1]),
+            self::channel($channels[2]),
+            // CSS states the opacity, GD the transparency, on a 128 step scale.
+            isset($channels[3]) ? self::alpha(self::channel($channels[3])) : 0,
+        );
+    }
+
+    public function isTransparent(): bool
+    {
+        return $this->alpha === 127;
+    }
+
+    /**
+     * @return int<0, 255>
+     */
+    private static function channel(string $hex): int
+    {
+        return max(0, min(255, (int) hexdec($hex)));
+    }
+
+    /**
+     * @param int<0, 255> $opacity
+     *
+     * @return int<0, 127>
+     */
+    private static function alpha(int $opacity): int
+    {
+        return max(0, min(127, (int) round((255 - $opacity) * 127 / 255)));
+    }
+
+    private static function unsupported(string $color): InvalidArgumentException
+    {
+        return new InvalidArgumentException(sprintf(
+            'The color "%s" is not supported. Use a CSS color name, "transparent", or an hexadecimal notation such as "#f00", "#f00c", "#ff0000" or "#ff0000cc".',
+            $color
+        ));
+    }
+}

--- a/src/ImageProcessor/Color.php
+++ b/src/ImageProcessor/Color.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace SpomkyLabs\PwaBundle\ImageProcessor;
 
+use function count;
 use InvalidArgumentException;
 use function mb_str_split;
 use function mb_strlen;
 use function mb_strtolower;
+use const PREG_SPLIT_NO_EMPTY;
 use function sprintf;
 
 /**
@@ -185,25 +187,28 @@ final readonly class Color
      * @param int<0, 255> $red
      * @param int<0, 255> $green
      * @param int<0, 255> $blue
-     * @param int<0, 127> $alpha On the GD scale: 0 is fully opaque, 127 fully transparent.
+     * @param int<0, 255> $opacity 0 is fully transparent, 255 fully opaque, as CSS states it.
      */
     private function __construct(
         public int $red,
         public int $green,
         public int $blue,
-        public int $alpha,
+        public int $opacity,
     ) {
     }
 
     /**
-     * Accepts a CSS colour name, the "transparent" keyword, or an hexadecimal notation with 3, 4, 6 or 8 digits and an
-     * optional leading "#".
+     * Accepts a CSS colour name, the "transparent" keyword, an hexadecimal notation with 3, 4, 6 or 8 digits and an
+     * optional leading "#", or one of the rgb(), rgba(), hsl() and hsla() functional notations.
      */
     public static function fromString(string $color): self
     {
         $normalized = mb_strtolower(trim($color));
         if ($normalized === 'transparent') {
-            return new self(0, 0, 0, 127);
+            return new self(0, 0, 0, 0);
+        }
+        if (str_contains($normalized, '(')) {
+            return self::fromFunctionalNotation($color, $normalized);
         }
         $normalized = self::NAMED_COLORS[$normalized] ?? $normalized;
 
@@ -219,41 +224,142 @@ final readonly class Color
         };
 
         return new self(
-            self::channel($channels[0]),
-            self::channel($channels[1]),
-            self::channel($channels[2]),
-            // CSS states the opacity, GD the transparency, on a 128 step scale.
-            isset($channels[3]) ? self::alpha(self::channel($channels[3])) : 0,
+            self::clamp((int) hexdec($channels[0])),
+            self::clamp((int) hexdec($channels[1])),
+            self::clamp((int) hexdec($channels[2])),
+            isset($channels[3]) ? self::clamp((int) hexdec($channels[3])) : 255,
         );
+    }
+
+    /**
+     * The transparency of the colour on the scale the GD extension uses: 0 is fully opaque, 127 fully transparent.
+     *
+     * @return int<0, 127>
+     */
+    public function gdAlpha(): int
+    {
+        return max(0, min(127, (int) round((255 - $this->opacity) * 127 / 255)));
     }
 
     public function isTransparent(): bool
     {
-        return $this->alpha === 127;
+        return $this->opacity === 0;
+    }
+
+    /**
+     * The "#RRGGBBAA" notation, which every ImagickPixel understands.
+     */
+    public function toHex(): string
+    {
+        return sprintf('#%02X%02X%02X%02X', $this->red, $this->green, $this->blue, $this->opacity);
+    }
+
+    private static function fromFunctionalNotation(string $color, string $normalized): self
+    {
+        if (preg_match('/^(rgba?|hsla?)\(\s*([^()]*?)\s*\)$/', $normalized, $matches) !== 1) {
+            throw self::unsupported($color);
+        }
+        // Both the legacy "rgb(255, 0, 0)" and the modern "rgb(255 0 0 / 50%)" separators are accepted.
+        $arguments = preg_split('#[\s,/]+#', $matches[2], -1, PREG_SPLIT_NO_EMPTY);
+        if ($arguments === false || count($arguments) < 3 || count($arguments) > 4) {
+            throw self::unsupported($color);
+        }
+        $opacity = isset($arguments[3]) ? self::opacity($color, $arguments[3]) : 255;
+
+        if (str_starts_with($matches[1], 'rgb')) {
+            return new self(
+                self::rgbChannel($color, $arguments[0]),
+                self::rgbChannel($color, $arguments[1]),
+                self::rgbChannel($color, $arguments[2]),
+                $opacity,
+            );
+        }
+
+        return self::fromHsl(
+            self::number($color, $arguments[0], 'deg'),
+            self::number($color, $arguments[1], '%') / 100,
+            self::number($color, $arguments[2], '%') / 100,
+            $opacity,
+        );
+    }
+
+    /**
+     * @param int<0, 255> $opacity
+     */
+    private static function fromHsl(float $hue, float $saturation, float $lightness, int $opacity): self
+    {
+        $hue = fmod(fmod($hue, 360) + 360, 360) / 60;
+        $saturation = max(0.0, min(1.0, $saturation));
+        $lightness = max(0.0, min(1.0, $lightness));
+
+        $chroma = (1 - abs(2 * $lightness - 1)) * $saturation;
+        $second = $chroma * (1 - abs(fmod($hue, 2.0) - 1));
+        $offset = $lightness - $chroma / 2;
+
+        [$red, $green, $blue] = match ((int) $hue) {
+            0 => [$chroma, $second, 0.0],
+            1 => [$second, $chroma, 0.0],
+            2 => [0.0, $chroma, $second],
+            3 => [0.0, $second, $chroma],
+            4 => [$second, 0.0, $chroma],
+            default => [$chroma, 0.0, $second],
+        };
+
+        return new self(
+            self::clamp((int) round(($red + $offset) * 255)),
+            self::clamp((int) round(($green + $offset) * 255)),
+            self::clamp((int) round(($blue + $offset) * 255)),
+            $opacity,
+        );
     }
 
     /**
      * @return int<0, 255>
      */
-    private static function channel(string $hex): int
+    private static function rgbChannel(string $color, string $argument): int
     {
-        return max(0, min(255, (int) hexdec($hex)));
+        return self::clamp((int) round(
+            str_ends_with($argument, '%')
+                ? self::number($color, $argument, '%') * 255 / 100
+                : self::number($color, $argument)
+        ));
     }
 
     /**
-     * @param int<0, 255> $opacity
-     *
-     * @return int<0, 127>
+     * @return int<0, 255>
      */
-    private static function alpha(int $opacity): int
+    private static function opacity(string $color, string $argument): int
     {
-        return max(0, min(127, (int) round((255 - $opacity) * 127 / 255)));
+        // The alpha channel is a fraction of one, unless it carries a percent sign.
+        return self::clamp((int) round(
+            str_ends_with($argument, '%')
+                ? self::number($color, $argument, '%') * 255 / 100
+                : self::number($color, $argument) * 255
+        ));
+    }
+
+    private static function number(string $color, string $argument, null|string $unit = null): float
+    {
+        $value = $unit === null ? $argument : rtrim($argument, $unit);
+        if (preg_match('/^[+-]?(?:\d+\.?\d*|\.\d+)$/', $value) !== 1) {
+            throw self::unsupported($color);
+        }
+
+        return (float) $value;
+    }
+
+    /**
+     * @return int<0, 255>
+     */
+    private static function clamp(int $value): int
+    {
+        return max(0, min(255, $value));
     }
 
     private static function unsupported(string $color): InvalidArgumentException
     {
         return new InvalidArgumentException(sprintf(
-            'The color "%s" is not supported. Use a CSS color name, "transparent", or an hexadecimal notation such as "#f00", "#f00c", "#ff0000" or "#ff0000cc".',
+            'The color "%s" is not supported. Use a CSS color name, "transparent", an hexadecimal notation such as "#f00", "#f00c", "#ff0000" or "#ff0000cc", or one of the rgb(), rgba(), hsl() and hsla() notations.',
             $color
         ));
     }

--- a/src/ImageProcessor/ConfigurationTrait.php
+++ b/src/ImageProcessor/ConfigurationTrait.php
@@ -9,6 +9,8 @@ use function is_int;
 use function is_string;
 
 /**
+ * The plumbing the bundled processors share.
+ *
  * @internal
  */
 trait ConfigurationTrait
@@ -17,6 +19,15 @@ trait ConfigurationTrait
      * @return array{width: int, height: int}
      */
     abstract public function getSizes(string $image): array;
+
+    /**
+     * Whether the source is an SVG document, which the two processors decline for reasons of their own: GD cannot
+     * rasterize one at all, and ImageMagick needs a delegate that is not always built in.
+     */
+    private function isSvg(string $image): bool
+    {
+        return str_contains(mb_strtolower(mb_substr($image, 0, 1024, '8bit')), '<svg');
+    }
 
     private function getConfiguration(
         string $image,

--- a/src/ImageProcessor/GDImageProcessor.php
+++ b/src/ImageProcessor/GDImageProcessor.php
@@ -80,7 +80,6 @@ final readonly class GDImageProcessor implements ImageProcessorInterface
         assert($image !== false);
         $width = imagesx($image);
         $height = imagesy($image);
-        imagedestroy($image);
 
         return [
             'width' => $width,
@@ -181,14 +180,14 @@ final readonly class GDImageProcessor implements ImageProcessorInterface
             return $background;
         }
 
-        $hex = ltrim($configuration->backgroundColor, '#');
-        /** @var int<0, 255> $r */
-        $r = max(0, min(255, (int) hexdec(mb_substr($hex, 0, 2))));
-        /** @var int<0, 255> $g */
-        $g = max(0, min(255, (int) hexdec(mb_substr($hex, 2, 2))));
-        /** @var int<0, 255> $b */
-        $b = max(0, min(255, (int) hexdec(mb_substr($hex, 4, 2))));
-        $color = imagecolorallocate($background, $r, $g, $b);
+        $backgroundColor = Color::fromString($configuration->backgroundColor);
+        $color = imagecolorallocatealpha(
+            $background,
+            $backgroundColor->red,
+            $backgroundColor->green,
+            $backgroundColor->blue,
+            $backgroundColor->alpha
+        );
         assert($color !== false);
         imagefill($background, 0, 0, $color);
 
@@ -196,13 +195,15 @@ final readonly class GDImageProcessor implements ImageProcessorInterface
             return $background;
         }
 
-        // Choose a ghost color (not used in the image)
-        do {
-            $r = random_int(0, 255);
-            $g = random_int(0, 255);
-            $b = random_int(0, 255);
-        } while (imagecolorexact($background, $r, $g, $b) < 0);
-        $ghostColor = imagecolorallocate($background, $r, $g, $b);
+        // The corners are cut out by flooding each of them up to a ghost outline, so that outline has to stand out
+        // from the flat background it is drawn over. Complementing the background always gives a distinct colour:
+        // 255 - n only equals n for a fractional n.
+        $ghostColor = imagecolorallocate(
+            $background,
+            255 - $backgroundColor->red,
+            255 - $backgroundColor->green,
+            255 - $backgroundColor->blue
+        );
         assert($ghostColor !== false);
 
         // Draw the border radius

--- a/src/ImageProcessor/GDImageProcessor.php
+++ b/src/ImageProcessor/GDImageProcessor.php
@@ -4,15 +4,37 @@ declare(strict_types=1);
 
 namespace SpomkyLabs\PwaBundle\ImageProcessor;
 
+use function array_key_exists;
 use function assert;
+use function function_exists;
 use GdImage;
+use function implode;
 use InvalidArgumentException;
 use function is_string;
 use function mb_strlen;
+use RuntimeException;
+use function sprintf;
+use Throwable;
 
 final readonly class GDImageProcessor implements ImageProcessorInterface
 {
     use ConfigurationTrait;
+
+    /**
+     * The supported formats, mapped to the GD function that writes them. The extension can be built without any of
+     * the last three, so the presence of the writer is what the format is checked against.
+     *
+     * @var array<string, string>
+     */
+    private const ENCODERS = [
+        'png' => 'imagepng',
+        'jpeg' => 'imagejpeg',
+        'gif' => 'imagegif',
+        'ico' => 'imagepng',
+        'bmp' => 'imagebmp',
+        'webp' => 'imagewebp',
+        'avif' => 'imageavif',
+    ];
 
     public function process(
         string $image,
@@ -22,53 +44,40 @@ final readonly class GDImageProcessor implements ImageProcessorInterface
         null|Configuration $configuration = null
     ): string {
         $configuration = $this->getConfiguration($image, $width, $height, $format, $configuration);
+        $encodedFormat = $this->supportedFormat($configuration->format);
         $mainImage = $this->createMainImage($image, $configuration);
         $background = $this->createBackground($configuration);
         imagecopy($background, $mainImage, 0, 0, 0, 0, $configuration->width, $configuration->height);
 
-        ob_start();
-        switch ($configuration->format) {
-            case 'jpeg':
-            case 'jpg':
-                imagejpeg($background);
-                break;
-            case 'png':
-                imagesavealpha($background, true);
-                imagepng($background);
-                break;
-            case 'gif':
-                imagegif($background);
-                break;
-            case 'ico':
-                ob_start();
-                imagesavealpha($background, true);
-                imagepng($background);
-                $pngData = ob_get_clean();
-                assert(is_string($pngData));
-
-                // @phpstan-ignore-next-line
-                echo pack('v3', 0, 1, 1);
-                // @phpstan-ignore-next-line
-                echo pack(
-                    'C4v2V2',
-                    $configuration->width,
-                    $configuration->height,
-                    0,
-                    0,
-                    1,
-                    32,
-                    mb_strlen($pngData, '8bit'),
-                    22
-                );
-                // @phpstan-ignore-next-line
-                echo $pngData;
-                break;
-            default:
-                throw new InvalidArgumentException('Unsupported format');
-        }
-        $result = ob_get_clean();
-        assert(is_string($result));
-        return $result;
+        return $this->capture(function () use ($background, $encodedFormat, $configuration): void {
+            switch ($encodedFormat) {
+                case 'png':
+                    imagesavealpha($background, true);
+                    imagepng($background);
+                    break;
+                case 'jpeg':
+                    imagejpeg($background, null, ImageFormat::QUALITY);
+                    break;
+                case 'gif':
+                    imagegif($background);
+                    break;
+                case 'bmp':
+                    // Uncompressed, as ImageMagick writes it: potrace reads the result of the silhouette pass.
+                    imagebmp($background, null, false);
+                    break;
+                case 'webp':
+                    imagesavealpha($background, true);
+                    imagewebp($background, null, ImageFormat::QUALITY);
+                    break;
+                case 'avif':
+                    imagesavealpha($background, true);
+                    imageavif($background, null, ImageFormat::QUALITY);
+                    break;
+                case 'ico':
+                    $this->writeIco($background, $configuration);
+                    break;
+            }
+        });
     }
 
     /**
@@ -76,85 +85,124 @@ final readonly class GDImageProcessor implements ImageProcessorInterface
      */
     public function getSizes(string $image): array
     {
-        $image = imagecreatefromstring($image);
-        assert($image !== false);
-        $width = imagesx($image);
-        $height = imagesy($image);
+        $source = $this->read($image);
 
         return [
-            'width' => $width,
-            'height' => $height,
+            'width' => imagesx($source),
+            'height' => imagesy($source),
         ];
+    }
+
+    /**
+     * A single image ICO, holding the PNG payload every browser still in use reads.
+     */
+    private function writeIco(GdImage $image, Configuration $configuration): void
+    {
+        $pngData = $this->capture(static function () use ($image): void {
+            imagesavealpha($image, true);
+            imagepng($image);
+        });
+
+        // @phpstan-ignore-next-line
+        echo pack('v3', 0, 1, 1);
+        // @phpstan-ignore-next-line
+        echo pack(
+            'C4v2V2',
+            $configuration->width,
+            $configuration->height,
+            0,
+            0,
+            1,
+            32,
+            mb_strlen($pngData, '8bit'),
+            22
+        );
+        // @phpstan-ignore-next-line
+        echo $pngData;
+    }
+
+    private function capture(callable $writer): string
+    {
+        ob_start();
+        try {
+            $writer();
+        } catch (Throwable $throwable) {
+            ob_end_clean();
+            throw $throwable;
+        }
+        $result = ob_get_clean();
+        assert(is_string($result));
+
+        return $result;
+    }
+
+    private function supportedFormat(string $format): string
+    {
+        $normalized = ImageFormat::normalize($format);
+        if (! array_key_exists($normalized, self::ENCODERS)) {
+            throw new InvalidArgumentException(sprintf(
+                'The "%s" format is not supported by the GD image processor. Supported formats are: %s.',
+                $format,
+                implode(', ', array_keys(self::ENCODERS))
+            ));
+        }
+        if (! function_exists(self::ENCODERS[$normalized])) {
+            throw new InvalidArgumentException(sprintf(
+                'The "%s" format requires the GD extension to provide %s().',
+                $format,
+                self::ENCODERS[$normalized]
+            ));
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * The GD warning is silenced because the failure is reported as an exception instead: it used to reach the output
+     * of the console command, then the assertion that followed turned into a TypeError in production, where
+     * assertions are compiled out.
+     */
+    private function read(string $image): GdImage
+    {
+        $source = @imagecreatefromstring($image);
+        if ($source !== false) {
+            return $source;
+        }
+        if ($this->isSvg($image)) {
+            throw new InvalidArgumentException(
+                'The GD image processor cannot read SVG images. Use the Imagick image processor, or point the configuration at a raster source.'
+            );
+        }
+
+        throw new InvalidArgumentException(
+            'The image cannot be read: its format is not recognized by the GD extension.'
+        );
     }
 
     private function createMainImage(string $image, Configuration $configuration): GdImage
     {
-        $mainImage = imagecreatefromstring($image);
-        assert($mainImage !== false);
-        $transparent = imagecolorallocatealpha($mainImage, 0, 0, 0, 127);
-        assert($transparent !== false);
+        $mainImage = $this->read($image);
         imagealphablending($mainImage, true);
         imagesavealpha($mainImage, true);
 
         if ($configuration->imageScale !== null) {
-            $width = imagesx($mainImage);
-            $height = imagesy($mainImage);
-            $newWidth = (int) ($width * $configuration->imageScale / 100);
-            $newHeight = (int) ($height * $configuration->imageScale / 100);
-            $dstWidth = (int) (($width - $newWidth) / 2);
-            $dstHeight = (int) (($height - $newHeight) / 2);
-
-            $newImage = imagecreatetruecolor($width, $height);
-            assert($newImage !== false);
-            imagefill($newImage, 0, 0, $transparent);
-            imagealphablending($newImage, false);
-            imagesavealpha($newImage, true);
-            imagecopyresampled(
-                $newImage,
-                $mainImage,
-                $dstWidth,
-                $dstHeight,
-                0,
-                0,
-                $newWidth,
-                $newHeight,
-                $width,
-                $height,
-            );
-            $mainImage = $newImage;
+            $mainImage = $this->applyScale($mainImage, $configuration->imageScale);
         }
-
-        /*if ($configuration->width === $configuration->height) {
-         * $mainImage = imagescale($mainImage, $configuration->width, $configuration->height);
-         * assert($mainImage !== false);
-         * return $mainImage;
-         * }*/
 
         $srcWidth = imagesx($mainImage);
         $srcHeight = imagesy($mainImage);
-        if ($configuration->width >= $configuration->height) {
-            $ratio = $srcHeight / $srcWidth;
-            $newWidth = (int) ($configuration->height / $ratio);
-            $newHeight = $configuration->height;
-        } else {
-            $ratio = $srcWidth / $srcHeight;
-            $newWidth = $configuration->width;
-            $newHeight = (int) ($configuration->width / $ratio);
-        }
+        // The whole source has to fit inside the target, centred, exactly like Imagick's best fit. Matching one side
+        // only used to let the other overflow the canvas, cropping every source that was less square than its target.
+        $ratio = min($configuration->width / $srcWidth, $configuration->height / $srcHeight);
+        $newWidth = max(1, (int) round($srcWidth * $ratio));
+        $newHeight = max(1, (int) round($srcHeight * $ratio));
 
-        $newImage = imagecreatetruecolor($configuration->width, $configuration->height);
-        assert($newImage !== false);
-        imagealphablending($newImage, false);
-        imagesavealpha($newImage, true);
-        imagefill($newImage, 0, 0, $transparent);
-
-        $dstX = (int) (($configuration->width - $newWidth) / 2);
-        $dstY = (int) (($configuration->height - $newHeight) / 2);
+        $newImage = $this->transparentCanvas($configuration->width, $configuration->height);
         imagecopyresampled(
             $newImage,
             $mainImage,
-            $dstX,
-            $dstY,
+            (int) (($configuration->width - $newWidth) / 2),
+            (int) (($configuration->height - $newHeight) / 2),
             0,
             0,
             $newWidth,
@@ -163,105 +211,200 @@ final readonly class GDImageProcessor implements ImageProcessorInterface
             $srcHeight,
         );
 
+        if ($configuration->monochrome) {
+            $this->desaturate($newImage);
+        }
+
         return $newImage;
+    }
+
+    /**
+     * Shrinks the image inside its own bounds, leaving the freed band transparent.
+     */
+    private function applyScale(GdImage $image, int $imageScale): GdImage
+    {
+        $width = imagesx($image);
+        $height = imagesy($image);
+        $newWidth = max(1, (int) ($width * $imageScale / 100));
+        $newHeight = max(1, (int) ($height * $imageScale / 100));
+
+        $canvas = $this->transparentCanvas($width, $height);
+        imagecopyresampled(
+            $canvas,
+            $image,
+            (int) (($width - $newWidth) / 2),
+            (int) (($height - $newHeight) / 2),
+            0,
+            0,
+            $newWidth,
+            $newHeight,
+            $width,
+            $height,
+        );
+
+        return $canvas;
+    }
+
+    /**
+     * Turns the image to greyscale, preserving its alpha channel.
+     *
+     * IMG_FILTER_GRAYSCALE would be one native call, but it weighs the channels the Rec. 601 way while ImageMagick
+     * weighs them the Rec. 709 way, which puts the two processors up to 22 levels apart on a saturated colour.
+     */
+    private function desaturate(GdImage $image): void
+    {
+        $width = imagesx($image);
+        $height = imagesy($image);
+        imagealphablending($image, false);
+        imagesavealpha($image, true);
+
+        for ($x = 0; $x < $width; $x++) {
+            for ($y = 0; $y < $height; $y++) {
+                $color = imagecolorat($image, $x, $y);
+                $luminance = (int) round(
+                    0.2126 * (($color >> 16) & 0xFF)
+                    + 0.7152 * (($color >> 8) & 0xFF)
+                    + 0.0722 * ($color & 0xFF)
+                );
+                imagesetpixel(
+                    $image,
+                    $x,
+                    $y,
+                    ($color & 0x7F000000) | ($luminance << 16) | ($luminance << 8) | $luminance
+                );
+            }
+        }
+
+        imagealphablending($image, true);
     }
 
     private function createBackground(Configuration $configuration): GdImage
     {
-        // Create a blank image
-        $background = imagecreatetruecolor($configuration->width, $configuration->height);
-        assert($background !== false);
-        $transparent = imagecolorallocatealpha($background, 0, 0, 0, 127);
-        assert($transparent !== false);
-
-        // Fill the image with the transparent color
         if ($configuration->backgroundColor === null) {
-            imagefill($background, 0, 0, $transparent);
+            $background = $this->transparentCanvas($configuration->width, $configuration->height);
+            imagealphablending($background, true);
+
             return $background;
         }
 
         $backgroundColor = Color::fromString($configuration->backgroundColor);
+        $background = $this->canvas($configuration->width, $configuration->height);
         $color = imagecolorallocatealpha(
             $background,
             $backgroundColor->red,
             $backgroundColor->green,
             $backgroundColor->blue,
-            $backgroundColor->alpha
+            $backgroundColor->gdAlpha()
         );
         assert($color !== false);
+        imagesavealpha($background, true);
         imagefill($background, 0, 0, $color);
 
-        if ($configuration->borderRadius === null) {
-            return $background;
+        if ($configuration->borderRadius !== null) {
+            $this->roundCorners($background, $configuration->borderRadius, $backgroundColor);
         }
 
-        // The corners are cut out by flooding each of them up to a ghost outline, so that outline has to stand out
-        // from the flat background it is drawn over. Complementing the background always gives a distinct colour:
-        // 255 - n only equals n for a fractional n.
-        $ghostColor = imagecolorallocate(
-            $background,
-            255 - $backgroundColor->red,
-            255 - $backgroundColor->green,
-            255 - $backgroundColor->blue
-        );
-        assert($ghostColor !== false);
+        return $background;
+    }
 
-        // Draw the border radius
-        $radiusX = (int) ($configuration->borderRadius * $configuration->width / 100);
-        $radiusY = (int) ($configuration->borderRadius * $configuration->height / 100);
+    /**
+     * Cuts the four corners out of the flat background, carrying the coverage of the pixels the ellipse only crosses
+     * in their alpha channel. Tracing an arc then flooding up to it left hard, aliased corners, where ImagickDraw has
+     * been antialiasing its rounded rectangle all along.
+     */
+    private function roundCorners(GdImage $background, int $borderRadius, Color $color): void
+    {
+        $width = imagesx($background);
+        $height = imagesy($background);
+        $radiusX = max(1, (int) round($borderRadius * $width / 100));
+        $radiusY = max(1, (int) round($borderRadius * $height / 100));
+        // Only the pixels within roughly one and a half pixel of the ellipse are partly covered; the rest is decided
+        // by the distance alone, which keeps the cost on the perimeter rather than on the whole corner.
+        $band = 1.5 / min($radiusX, $radiusY);
+        $opaqueAlpha = $color->gdAlpha();
 
-        imagearc($background, $radiusX - 1, $radiusY - 1, $radiusX * 2, $radiusY * 2, 180, 270, $ghostColor);
-        imagefilltoborder($background, 0, 0, $ghostColor, $transparent);
-        imagearc(
-            $background,
-            $configuration->width - $radiusX,
-            $radiusY - 1,
-            $radiusX * 2,
-            $radiusY * 2,
-            270,
-            0,
-            $ghostColor
-        );
-        imagefilltoborder($background, $configuration->width - 1, 0, $ghostColor, $transparent);
-        imagearc(
-            $background,
-            $radiusX - 1,
-            $configuration->height - $radiusY,
-            $radiusX * 2,
-            $radiusY * 2,
-            90,
-            180,
-            $ghostColor
-        );
-        imagefilltoborder($background, 0, $configuration->height - 1, $ghostColor, $transparent);
-        imagearc(
-            $background,
-            $configuration->width - $radiusX,
-            $configuration->height - $radiusY,
-            $radiusX * 2,
-            $radiusY * 2,
-            0,
-            90,
-            $ghostColor
-        );
-        imagefilltoborder(
-            $background,
-            $configuration->width - 1,
-            $configuration->height - 1,
-            $ghostColor,
-            $transparent
-        );
-
+        imagealphablending($background, false);
         imagesavealpha($background, true);
-        for ($x = imagesx($background); $x--;) {
-            for ($y = imagesy($background); $y--;) {
-                $c = imagecolorat($background, $x, $y);
-                if ($c === $ghostColor) {
-                    imagesetpixel($background, $x, $y, $color);
+
+        $corners = [
+            [$radiusX, $radiusY, 0, 0],
+            [$width - $radiusX, $radiusY, $width - $radiusX, 0],
+            [$radiusX, $height - $radiusY, 0, $height - $radiusY],
+            [$width - $radiusX, $height - $radiusY, $width - $radiusX, $height - $radiusY],
+        ];
+        foreach ($corners as [$centerX, $centerY, $originX, $originY]) {
+            for ($x = $originX; $x < $originX + $radiusX; $x++) {
+                for ($y = $originY; $y < $originY + $radiusY; $y++) {
+                    $distanceX = ($x + 0.5 - $centerX) / $radiusX;
+                    $distanceY = ($y + 0.5 - $centerY) / $radiusY;
+                    $distance = sqrt($distanceX ** 2 + $distanceY ** 2);
+                    if ($distance <= 1 - $band) {
+                        continue;
+                    }
+                    $coverage = $distance >= 1 + $band
+                        ? 0.0
+                        : $this->coverage($x, $y, $centerX, $centerY, $radiusX, $radiusY);
+                    $alpha = (int) round(127 - $coverage * (127 - $opaqueAlpha));
+                    imagesetpixel(
+                        $background,
+                        $x,
+                        $y,
+                        ($alpha << 24) | ($color->red << 16) | ($color->green << 8) | $color->blue
+                    );
                 }
             }
         }
 
-        return $background;
+        imagealphablending($background, true);
+    }
+
+    /**
+     * The share of the pixel the ellipse covers, sampled on a four by four grid.
+     */
+    private function coverage(int $x, int $y, int $centerX, int $centerY, int $radiusX, int $radiusY): float
+    {
+        $samples = 4;
+        $inside = 0;
+        for ($column = 0; $column < $samples; $column++) {
+            for ($row = 0; $row < $samples; $row++) {
+                $distanceX = ($x + ($column + 0.5) / $samples - $centerX) / $radiusX;
+                $distanceY = ($y + ($row + 0.5) / $samples - $centerY) / $radiusY;
+                if ($distanceX ** 2 + $distanceY ** 2 <= 1.0) {
+                    $inside++;
+                }
+            }
+        }
+
+        return $inside / $samples ** 2;
+    }
+
+    /**
+     * @param int<1, max> $width
+     * @param int<1, max> $height
+     */
+    private function transparentCanvas(int $width, int $height): GdImage
+    {
+        $canvas = $this->canvas($width, $height);
+        $transparent = imagecolorallocatealpha($canvas, 0, 0, 0, 127);
+        assert($transparent !== false);
+        imagealphablending($canvas, false);
+        imagesavealpha($canvas, true);
+        imagefill($canvas, 0, 0, $transparent);
+
+        return $canvas;
+    }
+
+    /**
+     * @param int<1, max> $width
+     * @param int<1, max> $height
+     */
+    private function canvas(int $width, int $height): GdImage
+    {
+        $canvas = imagecreatetruecolor($width, $height);
+        if ($canvas === false) {
+            throw new RuntimeException(sprintf('Unable to allocate a %dx%d image.', $width, $height));
+        }
+
+        return $canvas;
     }
 }

--- a/src/ImageProcessor/ImageFormat.php
+++ b/src/ImageProcessor/ImageFormat.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\ImageProcessor;
+
+use function mb_strtolower;
+
+/**
+ * The output format conventions both bundled processors follow.
+ *
+ * @internal
+ */
+final class ImageFormat
+{
+    /**
+     * The quality of the lossy encoders.
+     *
+     * Both processors used to leave it to their extension, which meant the very same configuration produced
+     * noticeably different files: GD fell back on its default of 75, while ImageMagick picked 92, or the quality of
+     * the source when that source was itself a JPEG. It is now stated explicitly on either side.
+     */
+    public const QUALITY = 85;
+
+    /**
+     * @var array<string, string>
+     */
+    private const ALIASES = [
+        'jpg' => 'jpeg',
+    ];
+
+    /**
+     * The format comes from the configuration, where it is a free scalar, or from the extension of the source asset.
+     * Neither is case normalized, and both spell JPEG either way.
+     */
+    public static function normalize(string $format): string
+    {
+        $normalized = mb_strtolower(trim($format));
+
+        return self::ALIASES[$normalized] ?? $normalized;
+    }
+}

--- a/src/ImageProcessor/ImagickImageProcessor.php
+++ b/src/ImageProcessor/ImagickImageProcessor.php
@@ -6,7 +6,11 @@ namespace SpomkyLabs\PwaBundle\ImageProcessor;
 
 use Imagick;
 use ImagickDraw;
+use ImagickException;
 use ImagickPixel;
+use ImagickPixelException;
+use InvalidArgumentException;
+use function sprintf;
 
 final readonly class ImagickImageProcessor implements ImageProcessorInterface
 {
@@ -23,27 +27,90 @@ final readonly class ImagickImageProcessor implements ImageProcessorInterface
         $mainImage = $this->createMainImage($image, $configuration);
         $background = $this->createBackground($configuration);
         $background->compositeImage($mainImage, Imagick::COMPOSITE_OVER, 0, 0);
-        $background->setImageFormat($configuration->format === 'png' ? 'png32' : $configuration->format);
 
-        return $background->getImageBlob();
+        return $this->encode($background, ImageFormat::normalize($configuration->format));
     }
 
     public function getSizes(string $image): array
     {
-        $imagick = new Imagick();
-        $imagick->readImageBlob($image);
+        $imagick = $this->read($image);
+
         return [
             'width' => $imagick->getImageWidth(),
             'height' => $imagick->getImageHeight(),
         ];
     }
 
+    /**
+     * A format ImageMagick was not built for is only reported when the blob is asked for, not when the format is set,
+     * so the whole encoding step is guarded. The reason ImageMagick gave is kept as the previous exception.
+     */
+    private function encode(Imagick $image, string $format): string
+    {
+        try {
+            $image->setImageFormat($format === 'png' ? 'png32' : $format);
+            $image->setImageCompressionQuality(ImageFormat::QUALITY);
+
+            return $image->getImageBlob();
+        } catch (ImagickException $exception) {
+            throw new InvalidArgumentException(
+                sprintf('The "%s" format is not supported by the Imagick image processor.', $format),
+                0,
+                $exception
+            );
+        }
+    }
+
+    /**
+     * ImagickException carries the internal ImageMagick wording, which says nothing of what to do about it; the
+     * failure is restated here, and the two processors report an unreadable source the same way.
+     */
+    private function read(string $image): Imagick
+    {
+        $imagick = new Imagick();
+        $imagick->setBackgroundColor(new ImagickPixel('transparent'));
+        try {
+            $imagick->readImageBlob($image);
+        } catch (ImagickException $exception) {
+            if ($this->isSvg($image)) {
+                throw new InvalidArgumentException(
+                    'The Imagick image processor cannot read this SVG image. ImageMagick has to be built with an SVG delegate, such as librsvg.',
+                    0,
+                    $exception
+                );
+            }
+
+            throw new InvalidArgumentException(
+                'The image cannot be read: its format is not recognized by ImageMagick.',
+                0,
+                $exception
+            );
+        }
+        $imagick->setImageBackgroundColor(new ImagickPixel('transparent'));
+
+        return $imagick;
+    }
+
+    /**
+     * Resolves the colour the way the GD processor does, so both accept the very same notations. ImageMagick knows
+     * colour names of its own beyond the CSS ones, which keep working through the fallback.
+     */
+    private function pixel(string $color): ImagickPixel
+    {
+        try {
+            return new ImagickPixel(Color::fromString($color)->toHex());
+        } catch (InvalidArgumentException $exception) {
+            try {
+                return new ImagickPixel($color);
+            } catch (ImagickPixelException) {
+                throw $exception;
+            }
+        }
+    }
+
     private function createMainImage(string $image, Configuration $configuration): Imagick
     {
-        $mainImage = new Imagick();
-        $mainImage->setBackgroundColor(new ImagickPixel('transparent'));
-        $mainImage->readImageBlob($image);
-        $mainImage->setImageBackgroundColor(new ImagickPixel('transparent'));
+        $mainImage = $this->read($image);
 
         if ($configuration->imageScale !== null) {
             $mainImage = $this->resizeImageWithScale($mainImage, $configuration->imageScale);
@@ -80,20 +147,23 @@ final readonly class ImagickImageProcessor implements ImageProcessorInterface
             $background->newImage(
                 $configuration->width,
                 $configuration->height,
-                new ImagickPixel($configuration->backgroundColor)
+                $this->pixel($configuration->backgroundColor)
             );
             return $background;
         }
 
         $rectangle = new ImagickDraw();
-        $rectangle->setFillColor(new ImagickPixel($configuration->backgroundColor));
+        $rectangle->setFillColor($this->pixel($configuration->backgroundColor));
+        // The last pixel of each axis is at width - 1: spanning the rectangle to width made the shape one pixel wider
+        // and one pixel taller than the canvas, and the overflow was clipped, leaving the bottom right corner visibly
+        // less rounded than the top left one.
         $rectangle->roundRectangle(
             0,
             0,
-            $configuration->width,
-            $configuration->height,
-            (int) ($configuration->borderRadius * $configuration->width / 100),
-            (int) ($configuration->borderRadius * $configuration->height / 100)
+            $configuration->width - 1,
+            $configuration->height - 1,
+            max(1, (int) round($configuration->borderRadius * $configuration->width / 100)),
+            max(1, (int) round($configuration->borderRadius * $configuration->height / 100))
         );
         $background = new Imagick();
         $background->newImage($configuration->width, $configuration->height, new ImagickPixel('transparent'));
@@ -118,6 +188,7 @@ final readonly class ImagickImageProcessor implements ImageProcessorInterface
         $mainImage->setImageBackgroundColor(new ImagickPixel('transparent'));
         $mainImage->compositeImage($image, Imagick::COMPOSITE_OVER, $x, $y);
         $mainImage->setImageFormat($image->getImageFormat());
+
         return $mainImage;
     }
 }

--- a/tests/Unit/ImageProcessor/ColorTest.php
+++ b/tests/Unit/ImageProcessor/ColorTest.php
@@ -95,7 +95,7 @@ final class ColorTest extends TestCase
     public function itRejectsWhatItCannotResolve(string $notation): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageIsOrContains(sprintf('The color "%s" is not supported.', $notation));
+        $this->expectExceptionMessage(sprintf('The color "%s" is not supported.', $notation));
 
         Color::fromString($notation);
     }

--- a/tests/Unit/ImageProcessor/ColorTest.php
+++ b/tests/Unit/ImageProcessor/ColorTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Tests\Unit\ImageProcessor;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\PwaBundle\ImageProcessor\Color;
+use function sprintf;
+
+/**
+ * @internal
+ */
+final class ColorTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('supportedNotations')]
+    public function itResolvesTheSupportedNotations(
+        string $notation,
+        int $red,
+        int $green,
+        int $blue,
+        int $alpha
+    ): void {
+        $color = Color::fromString($notation);
+
+        static::assertSame($red, $color->red);
+        static::assertSame($green, $color->green);
+        static::assertSame($blue, $color->blue);
+        static::assertSame($alpha, $color->alpha);
+    }
+
+    /**
+     * @return iterable<string, array{string, int, int, int, int}>
+     */
+    public static function supportedNotations(): iterable
+    {
+        yield 'six digits' => ['#ff0000', 255, 0, 0, 0];
+        yield 'six digits without the hash' => ['ff0000', 255, 0, 0, 0];
+        yield 'six digits in upper case' => ['#F5EF06', 245, 239, 6, 0];
+        yield 'three digits' => ['#f00', 255, 0, 0, 0];
+        yield 'three digits mixing channels' => ['#1a2', 17, 170, 34, 0];
+        yield 'eight digits, fully opaque' => ['#ff0000ff', 255, 0, 0, 0];
+        yield 'eight digits, half transparent' => ['#ff000080', 255, 0, 0, 63];
+        yield 'eight digits, fully transparent' => ['#ff000000', 255, 0, 0, 127];
+        yield 'four digits' => ['#f00c', 255, 0, 0, 25];
+        yield 'the transparent keyword' => ['transparent', 0, 0, 0, 127];
+        // The configuration documents colour names: ->example(['red', '#f5ef06']).
+        yield 'a colour name' => ['red', 255, 0, 0, 0];
+        yield 'a colour name in upper case' => ['WHITE', 255, 255, 255, 0];
+        yield 'a colour name with surrounding spaces' => [' rebeccapurple ', 102, 51, 153, 0];
+        yield 'the CSS grey, not the X11 one' => ['grey', 128, 128, 128, 0];
+    }
+
+    #[Test]
+    #[DataProvider('unsupportedNotations')]
+    public function itRejectsWhatItCannotResolve(string $notation): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageIsOrContains(sprintf('The color "%s" is not supported.', $notation));
+
+        Color::fromString($notation);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function unsupportedNotations(): iterable
+    {
+        yield 'an unknown name' => ['not-a-color'];
+        yield 'a functional notation' => ['rgb(255, 0, 0)'];
+        yield 'an empty string' => [''];
+        yield 'too few digits' => ['#ff'];
+        yield 'too many digits' => ['#ff0000ff00'];
+        yield 'an odd digit count' => ['#ff000'];
+        yield 'a non hexadecimal digit' => ['#ff00zz'];
+    }
+}

--- a/tests/Unit/ImageProcessor/ColorTest.php
+++ b/tests/Unit/ImageProcessor/ColorTest.php
@@ -23,14 +23,14 @@ final class ColorTest extends TestCase
         int $red,
         int $green,
         int $blue,
-        int $alpha
+        int $opacity
     ): void {
         $color = Color::fromString($notation);
 
         static::assertSame($red, $color->red);
         static::assertSame($green, $color->green);
         static::assertSame($blue, $color->blue);
-        static::assertSame($alpha, $color->alpha);
+        static::assertSame($opacity, $color->opacity);
     }
 
     /**
@@ -38,21 +38,56 @@ final class ColorTest extends TestCase
      */
     public static function supportedNotations(): iterable
     {
-        yield 'six digits' => ['#ff0000', 255, 0, 0, 0];
-        yield 'six digits without the hash' => ['ff0000', 255, 0, 0, 0];
-        yield 'six digits in upper case' => ['#F5EF06', 245, 239, 6, 0];
-        yield 'three digits' => ['#f00', 255, 0, 0, 0];
-        yield 'three digits mixing channels' => ['#1a2', 17, 170, 34, 0];
-        yield 'eight digits, fully opaque' => ['#ff0000ff', 255, 0, 0, 0];
-        yield 'eight digits, half transparent' => ['#ff000080', 255, 0, 0, 63];
-        yield 'eight digits, fully transparent' => ['#ff000000', 255, 0, 0, 127];
-        yield 'four digits' => ['#f00c', 255, 0, 0, 25];
-        yield 'the transparent keyword' => ['transparent', 0, 0, 0, 127];
+        yield 'six digits' => ['#ff0000', 255, 0, 0, 255];
+        yield 'six digits without the hash' => ['ff0000', 255, 0, 0, 255];
+        yield 'six digits in upper case' => ['#F5EF06', 245, 239, 6, 255];
+        yield 'three digits' => ['#f00', 255, 0, 0, 255];
+        yield 'three digits mixing channels' => ['#1a2', 17, 170, 34, 255];
+        yield 'eight digits, fully opaque' => ['#ff0000ff', 255, 0, 0, 255];
+        yield 'eight digits, half transparent' => ['#ff000080', 255, 0, 0, 128];
+        yield 'eight digits, fully transparent' => ['#ff000000', 255, 0, 0, 0];
+        yield 'four digits' => ['#f00c', 255, 0, 0, 204];
+        yield 'the transparent keyword' => ['transparent', 0, 0, 0, 0];
         // The configuration documents colour names: ->example(['red', '#f5ef06']).
-        yield 'a colour name' => ['red', 255, 0, 0, 0];
-        yield 'a colour name in upper case' => ['WHITE', 255, 255, 255, 0];
-        yield 'a colour name with surrounding spaces' => [' rebeccapurple ', 102, 51, 153, 0];
-        yield 'the CSS grey, not the X11 one' => ['grey', 128, 128, 128, 0];
+        yield 'a colour name' => ['red', 255, 0, 0, 255];
+        yield 'a colour name in upper case' => ['WHITE', 255, 255, 255, 255];
+        yield 'a colour name with surrounding spaces' => [' rebeccapurple ', 102, 51, 153, 255];
+        yield 'the CSS grey, not the X11 one' => ['grey', 128, 128, 128, 255];
+        // The functional notations only ImageMagick used to accept.
+        yield 'rgb()' => ['rgb(255, 0, 0)', 255, 0, 0, 255];
+        yield 'rgb() without spaces' => ['rgb(12,34,56)', 12, 34, 56, 255];
+        yield 'rgb() with percentages' => ['rgb(100%, 0%, 50%)', 255, 0, 128, 255];
+        yield 'rgba()' => ['rgba(255, 0, 0, 0.5)', 255, 0, 0, 128];
+        yield 'rgb() with the modern separators' => ['rgb(255 0 0 / 50%)', 255, 0, 0, 128];
+        yield 'hsl() red' => ['hsl(0, 100%, 50%)', 255, 0, 0, 255];
+        yield 'hsl() green' => ['hsl(120, 100%, 50%)', 0, 255, 0, 255];
+        yield 'hsl() blue' => ['hsl(240deg, 100%, 50%)', 0, 0, 255, 255];
+        yield 'hsl() grey' => ['hsl(0, 0%, 50%)', 128, 128, 128, 255];
+        yield 'hsla()' => ['hsla(0, 100%, 50%, 0.5)', 255, 0, 0, 128];
+    }
+
+    #[Test]
+    #[DataProvider('gdAlphas')]
+    public function itStatesTheTransparencyOnTheScaleGdUses(string $notation, int $expected): void
+    {
+        static::assertSame($expected, Color::fromString($notation)->gdAlpha());
+    }
+
+    /**
+     * @return iterable<string, array{string, int}>
+     */
+    public static function gdAlphas(): iterable
+    {
+        yield 'opaque' => ['#ff0000', 0];
+        yield 'half transparent' => ['#ff000080', 63];
+        yield 'fully transparent' => ['transparent', 127];
+    }
+
+    #[Test]
+    public function itRendersTheNotationImagickUnderstands(): void
+    {
+        static::assertSame('#FF0000FF', Color::fromString('red')->toHex());
+        static::assertSame('#FF000080', Color::fromString('#ff000080')->toHex());
     }
 
     #[Test]
@@ -71,11 +106,15 @@ final class ColorTest extends TestCase
     public static function unsupportedNotations(): iterable
     {
         yield 'an unknown name' => ['not-a-color'];
-        yield 'a functional notation' => ['rgb(255, 0, 0)'];
         yield 'an empty string' => [''];
         yield 'too few digits' => ['#ff'];
         yield 'too many digits' => ['#ff0000ff00'];
         yield 'an odd digit count' => ['#ff000'];
         yield 'a non hexadecimal digit' => ['#ff00zz'];
+        yield 'an unknown function' => ['cmyk(0, 1, 1, 0)'];
+        yield 'a functional notation with too few arguments' => ['rgb(255, 0)'];
+        yield 'a functional notation with too many arguments' => ['rgb(255, 0, 0, 1, 1)'];
+        yield 'a functional notation with a non numeric argument' => ['rgb(255, zero, 0)'];
+        yield 'an unclosed functional notation' => ['rgb(255, 0, 0'];
     }
 }

--- a/tests/Unit/ImageProcessor/GDImageProcessorTest.php
+++ b/tests/Unit/ImageProcessor/GDImageProcessorTest.php
@@ -4,23 +4,24 @@ declare(strict_types=1);
 
 namespace SpomkyLabs\PwaBundle\Tests\Unit\ImageProcessor;
 
-use function assert;
+use function function_exists;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\TestCase;
 use function restore_error_handler;
 use function set_error_handler;
 use SpomkyLabs\PwaBundle\ImageProcessor\Configuration;
 use SpomkyLabs\PwaBundle\ImageProcessor\GDImageProcessor;
+use SpomkyLabs\PwaBundle\ImageProcessor\ImageFormat;
+use SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface;
 use function sprintf;
 
 /**
  * @internal
  */
 #[RequiresPhpExtension('gd')]
-final class GDImageProcessorTest extends TestCase
+final class GDImageProcessorTest extends ImageProcessorTestCase
 {
     /**
      * PHP 8.5 deprecated imagedestroy(), and hexdec() has been complaining about non hexadecimal characters since 7.4.
@@ -60,107 +61,55 @@ final class GDImageProcessorTest extends TestCase
         yield 'ico' => [Configuration::create(64, 64, 'ico')];
         yield 'jpeg' => [Configuration::create(64, 64, 'jpeg')];
         yield 'gif' => [Configuration::create(64, 64, 'gif')];
+        foreach ([
+            'bmp' => 'imagebmp',
+            'webp' => 'imagewebp',
+            'avif' => 'imageavif',
+        ] as $format => $encoder) {
+            if (function_exists($encoder)) {
+                yield $format => [Configuration::create(64, 64, $format)];
+            }
+        }
         yield 'a hexadecimal background' => [Configuration::create(64, 64, 'png', '#f5ef06')];
         yield 'a named background' => [Configuration::create(64, 64, 'png', 'red')];
         yield 'a rounded background' => [Configuration::create(64, 64, 'png', 'red', 25)];
         yield 'a scaled image' => [Configuration::create(64, 64, 'png', null, null, 50)];
+        yield 'a monochrome icon' => [Configuration::create(64, 64, 'png', null, null, null, true)];
         yield 'a non square target' => [Configuration::create(310, 150, 'png')];
     }
 
-    /**
-     * The background colour notations the configuration documents have to reach the generated icon untouched.
-     */
     #[Test]
-    #[DataProvider('backgroundColors')]
-    public function itPaintsTheConfiguredBackgroundColor(string $notation, int $expected): void
+    public function itNamesTheAlternativeWhenHandedAnSvg(): void
     {
-        $processor = new GDImageProcessor();
-        // A fully transparent source lets the background show through.
-        $result = $processor->process(
-            self::sourceImage(8, 8, true),
-            null,
-            null,
-            null,
-            Configuration::create(64, 64, 'png', $notation)
-        );
-
-        static::assertSame($expected, self::pixelAt($result, 32, 32));
-    }
-
-    /**
-     * @return iterable<string, array{string, int}>
-     */
-    public static function backgroundColors(): iterable
-    {
-        yield 'a colour name' => ['red', 0x00FF0000];
-        yield 'the name used by the safari pinned tab' => ['white', 0x00FFFFFF];
-        yield 'the hexadecimal notation of the documentation' => ['#f5ef06', 0x00F5EF06];
-        yield 'the short hexadecimal notation' => ['#f00', 0x00FF0000];
-        yield 'the hexadecimal notation without a hash' => ['f5ef06', 0x00F5EF06];
-        yield 'a half transparent colour' => ['#ff000080', 0x3FFF0000];
-    }
-
-    #[Test]
-    public function itRejectsABackgroundColorItCannotResolve(): void
-    {
-        $processor = new GDImageProcessor();
-
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageIsOrContains('The color "rgb(255, 0, 0)" is not supported.');
+        $this->expectExceptionMessageIsOrContains('Use the Imagick image processor');
 
-        $processor->process(
-            self::sourceImage(8, 8),
-            null,
-            null,
-            null,
-            Configuration::create(64, 64, 'png', 'rgb(255, 0, 0)')
-        );
+        $this->processor()
+            ->getSizes('<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"></svg>');
     }
 
     #[Test]
-    public function itCutsTheCornersOutOfARoundedBackground(): void
+    public function itListsTheFormatsItWritesWhenHandedAnotherOne(): void
     {
-        $processor = new GDImageProcessor();
-        $result = $processor->process(
-            self::sourceImage(8, 8, true),
-            null,
-            null,
-            null,
-            Configuration::create(64, 64, 'png', 'red', 25)
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageIsOrContains('Supported formats are: png, jpeg, gif, ico, bmp, webp, avif.');
 
-        // Transparent on the corner, opaque halfway along the edge.
-        static::assertSame(127, self::pixelAt($result, 0, 0) >> 24);
-        static::assertSame(0x00FF0000, self::pixelAt($result, 32, 0));
+        $this->processor()
+            ->process(self::sourceImage(8, 8), null, null, null, Configuration::create(8, 8, 'tiff'));
     }
 
-    private static function sourceImage(int $width, int $height, bool $transparent = false): string
+    protected function processor(): ImageProcessorInterface
     {
-        $image = imagecreatetruecolor($width, $height);
-        assert($image !== false);
-        imagealphablending($image, false);
-        imagesavealpha($image, true);
-        $color = imagecolorallocatealpha($image, 0, 128, 255, $transparent ? 127 : 0);
-        assert($color !== false);
-        imagefill($image, 0, 0, $color);
-
-        ob_start();
-        imagepng($image);
-        $result = ob_get_clean();
-        assert($result !== false);
-
-        return $result;
+        return new GDImageProcessor();
     }
 
-    /**
-     * @return int The pixel as GD packs it: alpha on the high byte, then red, green and blue.
-     */
-    private static function pixelAt(string $png, int $x, int $y): int
+    protected function canWrite(string $format): bool
     {
-        $image = imagecreatefromstring($png);
-        assert($image !== false);
-        imagealphablending($image, false);
-
-        return imagecolorat($image, $x, $y);
+        return match (ImageFormat::normalize($format)) {
+            'bmp' => function_exists('imagebmp'),
+            'webp' => function_exists('imagewebp'),
+            'avif' => function_exists('imageavif'),
+            default => true,
+        };
     }
 }

--- a/tests/Unit/ImageProcessor/GDImageProcessorTest.php
+++ b/tests/Unit/ImageProcessor/GDImageProcessorTest.php
@@ -82,7 +82,7 @@ final class GDImageProcessorTest extends ImageProcessorTestCase
     public function itNamesTheAlternativeWhenHandedAnSvg(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageIsOrContains('Use the Imagick image processor');
+        $this->expectExceptionMessage('Use the Imagick image processor');
 
         $this->processor()
             ->getSizes('<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"></svg>');
@@ -92,7 +92,7 @@ final class GDImageProcessorTest extends ImageProcessorTestCase
     public function itListsTheFormatsItWritesWhenHandedAnotherOne(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageIsOrContains('Supported formats are: png, jpeg, gif, ico, bmp, webp, avif.');
+        $this->expectExceptionMessage('Supported formats are: png, jpeg, gif, ico, bmp, webp, avif.');
 
         $this->processor()
             ->process(self::sourceImage(8, 8), null, null, null, Configuration::create(8, 8, 'tiff'));

--- a/tests/Unit/ImageProcessor/GDImageProcessorTest.php
+++ b/tests/Unit/ImageProcessor/GDImageProcessorTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Tests\Unit\ImageProcessor;
+
+use function assert;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use function restore_error_handler;
+use function set_error_handler;
+use SpomkyLabs\PwaBundle\ImageProcessor\Configuration;
+use SpomkyLabs\PwaBundle\ImageProcessor\GDImageProcessor;
+use function sprintf;
+
+/**
+ * @internal
+ */
+#[RequiresPhpExtension('gd')]
+final class GDImageProcessorTest extends TestCase
+{
+    /**
+     * PHP 8.5 deprecated imagedestroy(), and hexdec() has been complaining about non hexadecimal characters since 7.4.
+     * Both used to fire while generating perfectly valid icons, so the whole processing surface is replayed here with
+     * every diagnostic turned into a failure.
+     */
+    #[Test]
+    #[DataProvider('representativeConfigurations')]
+    public function itProcessesImagesWithoutTriggeringAnyDiagnostic(Configuration $configuration): void
+    {
+        $processor = new GDImageProcessor();
+        $source = self::sourceImage(256, 192);
+
+        $diagnostics = [];
+        set_error_handler(static function (int $level, string $message) use (&$diagnostics): bool {
+            $diagnostics[] = sprintf('[%d] %s', $level, $message);
+            return true;
+        });
+
+        try {
+            $processor->getSizes($source);
+            $result = $processor->process($source, null, null, null, $configuration);
+        } finally {
+            restore_error_handler();
+        }
+
+        static::assertSame([], $diagnostics);
+        static::assertNotSame('', $result);
+    }
+
+    /**
+     * @return iterable<string, array{Configuration}>
+     */
+    public static function representativeConfigurations(): iterable
+    {
+        yield 'png' => [Configuration::create(64, 64, 'png')];
+        yield 'ico' => [Configuration::create(64, 64, 'ico')];
+        yield 'jpeg' => [Configuration::create(64, 64, 'jpeg')];
+        yield 'gif' => [Configuration::create(64, 64, 'gif')];
+        yield 'a hexadecimal background' => [Configuration::create(64, 64, 'png', '#f5ef06')];
+        yield 'a named background' => [Configuration::create(64, 64, 'png', 'red')];
+        yield 'a rounded background' => [Configuration::create(64, 64, 'png', 'red', 25)];
+        yield 'a scaled image' => [Configuration::create(64, 64, 'png', null, null, 50)];
+        yield 'a non square target' => [Configuration::create(310, 150, 'png')];
+    }
+
+    /**
+     * The background colour notations the configuration documents have to reach the generated icon untouched.
+     */
+    #[Test]
+    #[DataProvider('backgroundColors')]
+    public function itPaintsTheConfiguredBackgroundColor(string $notation, int $expected): void
+    {
+        $processor = new GDImageProcessor();
+        // A fully transparent source lets the background show through.
+        $result = $processor->process(
+            self::sourceImage(8, 8, true),
+            null,
+            null,
+            null,
+            Configuration::create(64, 64, 'png', $notation)
+        );
+
+        static::assertSame($expected, self::pixelAt($result, 32, 32));
+    }
+
+    /**
+     * @return iterable<string, array{string, int}>
+     */
+    public static function backgroundColors(): iterable
+    {
+        yield 'a colour name' => ['red', 0x00FF0000];
+        yield 'the name used by the safari pinned tab' => ['white', 0x00FFFFFF];
+        yield 'the hexadecimal notation of the documentation' => ['#f5ef06', 0x00F5EF06];
+        yield 'the short hexadecimal notation' => ['#f00', 0x00FF0000];
+        yield 'the hexadecimal notation without a hash' => ['f5ef06', 0x00F5EF06];
+        yield 'a half transparent colour' => ['#ff000080', 0x3FFF0000];
+    }
+
+    #[Test]
+    public function itRejectsABackgroundColorItCannotResolve(): void
+    {
+        $processor = new GDImageProcessor();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageIsOrContains('The color "rgb(255, 0, 0)" is not supported.');
+
+        $processor->process(
+            self::sourceImage(8, 8),
+            null,
+            null,
+            null,
+            Configuration::create(64, 64, 'png', 'rgb(255, 0, 0)')
+        );
+    }
+
+    #[Test]
+    public function itCutsTheCornersOutOfARoundedBackground(): void
+    {
+        $processor = new GDImageProcessor();
+        $result = $processor->process(
+            self::sourceImage(8, 8, true),
+            null,
+            null,
+            null,
+            Configuration::create(64, 64, 'png', 'red', 25)
+        );
+
+        // Transparent on the corner, opaque halfway along the edge.
+        static::assertSame(127, self::pixelAt($result, 0, 0) >> 24);
+        static::assertSame(0x00FF0000, self::pixelAt($result, 32, 0));
+    }
+
+    private static function sourceImage(int $width, int $height, bool $transparent = false): string
+    {
+        $image = imagecreatetruecolor($width, $height);
+        assert($image !== false);
+        imagealphablending($image, false);
+        imagesavealpha($image, true);
+        $color = imagecolorallocatealpha($image, 0, 128, 255, $transparent ? 127 : 0);
+        assert($color !== false);
+        imagefill($image, 0, 0, $color);
+
+        ob_start();
+        imagepng($image);
+        $result = ob_get_clean();
+        assert($result !== false);
+
+        return $result;
+    }
+
+    /**
+     * @return int The pixel as GD packs it: alpha on the high byte, then red, green and blue.
+     */
+    private static function pixelAt(string $png, int $x, int $y): int
+    {
+        $image = imagecreatefromstring($png);
+        assert($image !== false);
+        imagealphablending($image, false);
+
+        return imagecolorat($image, $x, $y);
+    }
+}

--- a/tests/Unit/ImageProcessor/ImageProcessorTestCase.php
+++ b/tests/Unit/ImageProcessor/ImageProcessorTestCase.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Tests\Unit\ImageProcessor;
+
+use function assert;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\PwaBundle\ImageProcessor\Configuration;
+use SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface;
+use function sprintf;
+
+/**
+ * The behaviour both bundled processors owe their callers.
+ *
+ * The two used to answer the same configuration quite differently: GD knew five formats where Imagick knew every one
+ * ImageMagick writes, resolved "red" to a near black colour, ignored the monochrome flag, and cropped whatever source
+ * was less square than its target instead of fitting it inside. Every expectation below is checked against both, so
+ * neither drifts away from the other again.
+ *
+ * @internal
+ */
+abstract class ImageProcessorTestCase extends TestCase
+{
+    #[Test]
+    public function itReadsTheSizeOfTheSource(): void
+    {
+        static::assertSame(
+            [
+                'width' => 128,
+                'height' => 64,
+            ],
+            $this->processor()
+                ->getSizes(self::sourceImage(128, 64))
+        );
+    }
+
+    #[Test]
+    #[DataProvider('formats')]
+    public function itWritesTheSupportedFormats(string $format, string $magic, int $offset = 0): void
+    {
+        // The codecs behind WebP and AVIF are build options of either library, and a build without them is not a
+        // regression of the bundle.
+        if (! $this->canWrite($format)) {
+            static::markTestSkipped(sprintf('This build cannot write the "%s" format.', $format));
+        }
+
+        $result = $this->processor()
+            ->process(self::sourceImage(32, 32), null, null, null, Configuration::create(32, 32, $format));
+
+        static::assertSame($magic, bin2hex(mb_substr($result, $offset, mb_strlen($magic, '8bit') / 2, '8bit')));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}|array{string, string, int}>
+     */
+    public static function formats(): iterable
+    {
+        yield 'png' => ['png', '89504e47'];
+        yield 'jpeg' => ['jpeg', 'ffd8ff'];
+        // The format also comes from the extension of the source asset, which spells JPEG the short way.
+        yield 'jpg' => ['jpg', 'ffd8ff'];
+        yield 'gif' => ['gif', '474946'];
+        yield 'ico' => ['ico', '00000100'];
+        // The silhouette of the Safari pinned tab is handed to potrace as a BMP.
+        yield 'bmp' => ['bmp', '424d'];
+        yield 'webp' => ['webp', '52494646'];
+        // "ftypavif", behind the size of the first ISO base media file format box.
+        yield 'avif' => ['avif', '6674797061766966', 4];
+        // The configuration takes the format as a free scalar, in whatever case it was written.
+        yield 'PNG' => ['PNG', '89504e47'];
+        yield 'JPEG' => ['JPEG', 'ffd8ff'];
+    }
+
+    #[Test]
+    public function itRejectsAFormatItCannotWrite(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageIsOrContains('not-a-format');
+
+        $this->processor()
+            ->process(self::sourceImage(32, 32), null, null, null, Configuration::create(32, 32, 'not-a-format'));
+    }
+
+    #[Test]
+    #[DataProvider('backgroundColors')]
+    public function itPaintsTheConfiguredBackgroundColor(string $notation, int $expected): void
+    {
+        // A fully transparent source lets the background show through.
+        $result = $this->processor()
+            ->process(
+                self::sourceImage(8, 8, transparent: true),
+                null,
+                null,
+                null,
+                Configuration::create(64, 64, 'png', $notation)
+            );
+
+        static::assertSame($expected, self::pixelAt($result, 32, 32));
+    }
+
+    /**
+     * @return iterable<string, array{string, int}>
+     */
+    public static function backgroundColors(): iterable
+    {
+        // The configuration documents both notations: ->example(['red', '#f5ef06']).
+        yield 'a colour name' => ['red', 0x00FF0000];
+        yield 'the name the safari pinned tab uses' => ['white', 0x00FFFFFF];
+        yield 'six hexadecimal digits' => ['#f5ef06', 0x00F5EF06];
+        yield 'six hexadecimal digits without the hash' => ['f5ef06', 0x00F5EF06];
+        yield 'three hexadecimal digits' => ['#f00', 0x00FF0000];
+        yield 'eight hexadecimal digits' => ['#ff000080', 0x3FFF0000];
+        yield 'rgb()' => ['rgb(255, 0, 0)', 0x00FF0000];
+        yield 'hsl()' => ['hsl(0, 100%, 50%)', 0x00FF0000];
+    }
+
+    #[Test]
+    public function itRejectsABackgroundColorItCannotResolve(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageIsOrContains('not-a-color');
+
+        $this->processor()
+            ->process(
+                self::sourceImage(8, 8),
+                null,
+                null,
+                null,
+                Configuration::create(64, 64, 'png', 'not-a-color')
+            );
+    }
+
+    /**
+     * A source wider than its target has to be fitted inside it, not cropped by it.
+     */
+    #[Test]
+    public function itFitsTheWholeSourceInsideTheTarget(): void
+    {
+        $result = $this->processor()
+            ->process(self::sourceImage(1024, 256), null, null, null, Configuration::create(512, 512, 'png'));
+
+        // 1024x256 inside 512x512 leaves a 512x128 band, centred: rows 192 to 320.
+        static::assertSame(127, self::alphaAt($result, 256, 10), 'the band above the image should be transparent');
+        static::assertSame(0, self::alphaAt($result, 256, 256), 'the image itself should be opaque');
+        static::assertSame(127, self::alphaAt($result, 256, 500), 'the band below the image should be transparent');
+        static::assertSame(0, self::alphaAt($result, 4, 256), 'the image should span the whole width');
+    }
+
+    #[Test]
+    public function itTurnsAMonochromeIconToGrey(): void
+    {
+        $result = $this->processor()
+            ->process(
+                self::sourceImage(64, 64),
+                null,
+                null,
+                null,
+                Configuration::create(64, 64, 'png', null, null, null, true)
+            );
+
+        $pixel = self::pixelAt($result, 32, 32);
+        $red = ($pixel >> 16) & 0xFF;
+        $green = ($pixel >> 8) & 0xFF;
+        $blue = $pixel & 0xFF;
+
+        static::assertSame($red, $green);
+        static::assertSame($green, $blue);
+        // The Rec. 709 luminance of the rgb(0, 128, 255) source, which is what ImageMagick applies.
+        static::assertEqualsWithDelta(110, $red, 2.0);
+    }
+
+    #[Test]
+    public function itRoundsTheCornersOfTheBackground(): void
+    {
+        $result = $this->processor()
+            ->process(
+                self::sourceImage(8, 8, transparent: true),
+                null,
+                null,
+                null,
+                Configuration::create(128, 128, 'png', 'red', 25)
+            );
+
+        static::assertSame(127, self::alphaAt($result, 0, 0), 'the corner should be cut out');
+        static::assertSame(0, self::alphaAt($result, 64, 0), 'the middle of the edge should be kept');
+
+        $antialiased = 0;
+        for ($x = 0; $x < 128; $x++) {
+            for ($y = 0; $y < 128; $y++) {
+                $alpha = self::alphaAt($result, $x, $y);
+                if ($alpha > 0 && $alpha < 127) {
+                    $antialiased++;
+                }
+            }
+        }
+        static::assertGreaterThan(100, $antialiased, 'the rounded edge should be antialiased');
+    }
+
+    #[Test]
+    public function itRejectsASourceItCannotRead(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageIsOrContains('The image cannot be read');
+
+        $this->processor()
+            ->getSizes('not an image at all');
+    }
+
+    abstract protected function processor(): ImageProcessorInterface;
+
+    /**
+     * Whether the library behind the processor was built with the codec of that format.
+     */
+    abstract protected function canWrite(string $format): bool;
+
+    /**
+     * A solid rgb(0, 128, 255) image, opaque unless asked otherwise.
+     */
+    protected static function sourceImage(int $width, int $height, bool $transparent = false): string
+    {
+        $image = imagecreatetruecolor($width, $height);
+        assert($image !== false);
+        imagealphablending($image, false);
+        imagesavealpha($image, true);
+        $color = imagecolorallocatealpha($image, 0, 128, 255, $transparent ? 127 : 0);
+        assert($color !== false);
+        imagefill($image, 0, 0, $color);
+
+        ob_start();
+        imagepng($image);
+        $result = ob_get_clean();
+        assert($result !== false);
+
+        return $result;
+    }
+
+    /**
+     * @return int The pixel as GD packs it: alpha on the high byte, then red, green and blue.
+     */
+    protected static function pixelAt(string $png, int $x, int $y): int
+    {
+        $image = imagecreatefromstring($png);
+        assert($image !== false, sprintf('The %d bytes long result is not a readable image.', mb_strlen($png, '8bit')));
+        imagealphablending($image, false);
+
+        return imagecolorat($image, $x, $y);
+    }
+
+    /**
+     * @return int 0 is fully opaque, 127 fully transparent.
+     */
+    protected static function alphaAt(string $png, int $x, int $y): int
+    {
+        return (self::pixelAt($png, $x, $y) >> 24) & 0x7F;
+    }
+}

--- a/tests/Unit/ImageProcessor/ImageProcessorTestCase.php
+++ b/tests/Unit/ImageProcessor/ImageProcessorTestCase.php
@@ -79,7 +79,7 @@ abstract class ImageProcessorTestCase extends TestCase
     public function itRejectsAFormatItCannotWrite(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageIsOrContains('not-a-format');
+        $this->expectExceptionMessage('not-a-format');
 
         $this->processor()
             ->process(self::sourceImage(32, 32), null, null, null, Configuration::create(32, 32, 'not-a-format'));
@@ -122,7 +122,7 @@ abstract class ImageProcessorTestCase extends TestCase
     public function itRejectsABackgroundColorItCannotResolve(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageIsOrContains('not-a-color');
+        $this->expectExceptionMessage('not-a-color');
 
         $this->processor()
             ->process(
@@ -187,24 +187,18 @@ abstract class ImageProcessorTestCase extends TestCase
 
         static::assertSame(127, self::alphaAt($result, 0, 0), 'the corner should be cut out');
         static::assertSame(0, self::alphaAt($result, 64, 0), 'the middle of the edge should be kept');
-
-        $antialiased = 0;
-        for ($x = 0; $x < 128; $x++) {
-            for ($y = 0; $y < 128; $y++) {
-                $alpha = self::alphaAt($result, $x, $y);
-                if ($alpha > 0 && $alpha < 127) {
-                    $antialiased++;
-                }
-            }
-        }
-        static::assertGreaterThan(100, $antialiased, 'the rounded edge should be antialiased');
+        static::assertGreaterThan(
+            100,
+            self::countPartiallyTransparentPixels($result),
+            'the rounded edge should be antialiased'
+        );
     }
 
     #[Test]
     public function itRejectsASourceItCannotRead(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageIsOrContains('The image cannot be read');
+        $this->expectExceptionMessage('The image cannot be read');
 
         $this->processor()
             ->getSizes('not an image at all');
@@ -256,5 +250,29 @@ abstract class ImageProcessorTestCase extends TestCase
     protected static function alphaAt(string $png, int $x, int $y): int
     {
         return (self::pixelAt($png, $x, $y) >> 24) & 0x7F;
+    }
+
+    /**
+     * The pixels an antialiased edge leaves between the two extremes, over a single decoding of the image.
+     */
+    protected static function countPartiallyTransparentPixels(string $png): int
+    {
+        $image = imagecreatefromstring($png);
+        assert($image !== false);
+        imagealphablending($image, false);
+        $width = imagesx($image);
+        $height = imagesy($image);
+
+        $count = 0;
+        for ($x = 0; $x < $width; $x++) {
+            for ($y = 0; $y < $height; $y++) {
+                $alpha = (imagecolorat($image, $x, $y) >> 24) & 0x7F;
+                if ($alpha > 0 && $alpha < 127) {
+                    $count++;
+                }
+            }
+        }
+
+        return $count;
     }
 }

--- a/tests/Unit/ImageProcessor/ImagickImageProcessorTest.php
+++ b/tests/Unit/ImageProcessor/ImagickImageProcessorTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Tests\Unit\ImageProcessor;
+
+use Imagick;
+use ImagickPixel;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\Attributes\Test;
+use SpomkyLabs\PwaBundle\ImageProcessor\Configuration;
+use SpomkyLabs\PwaBundle\ImageProcessor\ImageFormat;
+use SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface;
+use SpomkyLabs\PwaBundle\ImageProcessor\ImagickImageProcessor;
+use Throwable;
+
+/**
+ * @internal
+ */
+#[RequiresPhpExtension('gd')]
+#[RequiresPhpExtension('imagick')]
+final class ImagickImageProcessorTest extends ImageProcessorTestCase
+{
+    /**
+     * An SVG source is the one thing the two processors cannot answer alike: GD never rasterizes one, while
+     * ImageMagick does whenever it was built with a delegate for it. What is owed either way is a message stating
+     * which of the two situations the caller is in.
+     */
+    #[Test]
+    public function itReadsAnSvgSourceOrNamesTheMissingDelegate(): void
+    {
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="8"><rect width="16" height="8" fill="red"/></svg>';
+
+        try {
+            $sizes = $this->processor()
+                ->getSizes($svg);
+        } catch (InvalidArgumentException $exception) {
+            static::assertStringContainsString('SVG delegate', $exception->getMessage());
+            return;
+        }
+
+        static::assertSame(
+            [
+                'width' => 16,
+                'height' => 8,
+            ],
+            $sizes
+        );
+    }
+
+    /**
+     * ImageMagick writes far more than the formats the two processors have in common, and that stays true.
+     */
+    #[Test]
+    public function itKeepsWritingTheFormatsOnlyImageMagickKnows(): void
+    {
+        $result = $this->processor()
+            ->process(self::sourceImage(32, 32), null, null, null, Configuration::create(32, 32, 'tiff'));
+
+        static::assertNotSame('', $result);
+    }
+
+    /**
+     * ImageMagick knows colour names of its own, beyond the CSS ones the two processors share.
+     */
+    #[Test]
+    public function itKeepsResolvingTheColorNamesOnlyImageMagickKnows(): void
+    {
+        $result = $this->processor()
+            ->process(
+                self::sourceImage(8, 8, transparent: true),
+                null,
+                null,
+                null,
+                Configuration::create(64, 64, 'png', 'gray10')
+            );
+
+        static::assertSame(0, self::alphaAt($result, 32, 32));
+    }
+
+    protected function processor(): ImageProcessorInterface
+    {
+        return new ImagickImageProcessor();
+    }
+
+    /**
+     * Imagick::queryFormats() lists the formats ImageMagick registered, including those whose delegate is declared but
+     * unusable, so the encoder is the only reliable answer.
+     */
+    protected function canWrite(string $format): bool
+    {
+        try {
+            $image = new Imagick();
+            $image->newImage(1, 1, new ImagickPixel('red'));
+            $image->setImageFormat(ImageFormat::normalize($format));
+            $image->getImageBlob();
+
+            return true;
+        } catch (Throwable) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
- [x] It is a Bug fix
- [x] It is a New feature
- [x] Breaks BC
- [ ] Includes Deprecations

Picks up the note left at the bottom of #462: *"The `imagedestroy()` deprecation PHPStan reports under PHP 8.5 in `GDImageProcessor`. It predates this branch and belongs with whatever handles PHP 8.5 support as a whole."*

Silencing it took three lines. Looking for what else PHP 8.5 had to say about the processors surfaced a second deprecation that PHPStan cannot see, and from there a set of differences between the two bundled processors that go well past diagnostics: the choice between GD and Imagick is meant to be an implementation detail, and it was not one.

The first commit is the PHP 8.5 fix alone and stands without the rest; the second is the alignment; the third keeps the new tests on the PHPUnit the test job actually runs.

## PHP 8.5

**`imagedestroy()`** was called on every `getSizes()`. Deprecated in 8.5, and without effect since 8.0 turned GD resources into objects, so it is dropped rather than guarded.

**`hexdec()` on non hexadecimal characters** has been deprecated since PHP 7.4, so this one was firing on every supported version. The background colour was cut into two character slices and handed straight to `hexdec()`, and the configuration documents colour names everywhere — `->example(['red', '#f5ef06'])`. So `red` both warned twice and resolved to `#0E0D00`.

| configuration | before | after |
|---|---|---|
| `red` | `#0E0D00` + 1 deprecation | `#FF0000` |
| `white` | `#00000E` + 2 deprecations | `#FFFFFF` |
| `#f00` | `#F00000` | `#FF0000` |
| `#ff000080` | opaque, alpha dropped | alpha honoured |
| `rgb(255,0,0)` | `#000B25` + 2 deprecations | resolved |

A `Color` value object now resolves the 148 CSS Color Level 4 names, `transparent`, and the 3, 4, 6 and 8 digit hexadecimal forms. Its table was checked entry by entry against `ImagickPixel`: 145 of 148 agree. The three that do not are ImageMagick's own quirks — it reads `gray` as `#7E7E7E`, `grey` as the X11 `#BEBEBE` rather than `#808080`, and does not know `rebeccapurple` at all — and are resolved the CSS way on both sides.

While in there, the ghost colour of the rounded background was picked by `do { random_int() } while (imagecolorexact(…) < 0)`. On a truecolor image `imagecolorexact()` never returns `-1`, so the loop ran exactly once and the outline was a random colour with no guarantee of differing from the background it was drawn over. It is now the complement of that background, which is deterministic and, since `255 - n` only equals `n` for a fractional `n`, always distinct.

## The two processors did not answer alike

### Formats

GD knew `png`, `jpeg`, `gif` and `ico` and threw at anything else, from a case sensitive `switch`. Both `icons.format` and `screenshots.format` are free scalars, and an icon otherwise takes the extension of its source asset, so `PNG` or `webp` reached that `switch` and failed.

`bmp` is the one that mattered: `generateSilhouette()` asks for one to hand to potrace, so **the Safari pinned tab could only ever fail under GD** — while `imagebmp()` has been in the extension since PHP 7.2. GD now writes `bmp`, `webp` and `avif` as well, and both processors normalize the case first, `jpg` included. A format whose encoder the build lacks is reported as such rather than crashing.

### Fit

GD matched one side of the canvas exactly and let the other overflow, so the canvas cropped it. Which side depended on the target, not on the source: the height for a square or landscape canvas, the width for a portrait one. A 4:1 wordmark therefore came through intact on the iOS startup image and lost three quarters of itself on every square icon, while the same mark turned a quarter round did the opposite.

| source | target | GD before | GD after, and Imagick |
|---|---|---|---|
| 1024×256 | 512×512 | filled, 75% cut off | 512×128 centred |
| 1024×256 | 310×150 | filled, 48% cut off | 310×78 centred |
| 1024×256 | 180×180 | filled, 75% cut off | 180×45 centred |
| 256×1024 | 390×844 | filled, 46% cut off | 211×844 centred |

It now scales by the smaller of the two ratios and centres the result, which is what `scaleImage(…, bestfit)` already computed on the Imagick side — including the rounding, which matches `round()` and not `floor()` on all sixteen combinations tested.

A square source is unaffected: matching one side is the same as fitting inside.

### Monochrome

Read by Imagick, ignored by GD, which returned bytes identical to the non-monochrome ones. GD now weighs the channels the Rec. 709 way ImageMagick does. `IMG_FILTER_GRAYSCALE` would have been one native call but weighs them the Rec. 601 way, which puts the two processors up to 22 levels apart on a saturated colour — 76 against 54 on pure red.

### Rounded corners

GD traced an arc, flooded up to it, then scanned every pixel of the image to replace the outline: 0 antialiased pixels against 336 on the Imagick side, at no advantage in time. The corners are now cut out by coverage, sampled on a 4×4 grid and only within a pixel and a half of the ellipse, which keeps the cost on the perimeter. It comes out slightly faster than Imagick on the same canvas.

Imagick had a defect of its own: `roundRectangle(0, 0, $width, $height, …)` spans the last pixel of each axis, so the shape was one pixel wider and taller than the canvas and the overflow was clipped, leaving the bottom right corner visibly less rounded than the top left one. Now spanned to `$width - 1`.

### Colours, both ways

GD accepted `ff0000` without the hash and Imagick did not; Imagick resolved `rgb()` and `hsl()` and GD did not. Both now accept the CSS names, the hexadecimal forms with or without the hash, and `rgb()`, `rgba()`, `hsl()` and `hsla()` in either the legacy or the modern separator syntax. Imagick keeps the colour names only ImageMagick knows, through a fallback, and keeps writing the formats only ImageMagick writes.

### Quality

GD left JPEG to its own default of 75 while ImageMagick picked 92 — or the quality of the source, when that source was itself a JPEG, which made the output depend on the input in a way nothing else here does. Both now state 85 explicitly, for JPEG, WebP and AVIF alike.

### Unreadable sources

GD relied on `assert()`, which is compiled out in production: what should have been an `AssertionError` surfaced there as `TypeError: imagesx(): Argument #1 ($image) must be of type GdImage, false given`. Both processors now raise an `InvalidArgumentException`, and both name SVG when that is what they were handed, since the two decline it for different reasons — GD cannot rasterize one at all, ImageMagick needs a delegate it is not always built with. The favicon source is documented as *"Shall be a SVG or large PNG"* and reaches the processor as raw bytes, so this is a message users will see.

## Verification

`tests/Unit/ImageProcessor/ImageProcessorTestCase.php` holds every expectation the two processors owe their callers and is run against both, so they cannot drift apart again without the suite going red. 107 tests added over the processors, where there were none: neither had a single test before this branch.

`GDImageProcessorTest::itProcessesImagesWithoutTriggeringAnyDiagnostic()` replays the whole processing surface behind a `set_error_handler()` that fails on anything at all, which is what pins the two deprecations down — `SYMFONY_DEPRECATIONS_HELPER` is disabled in the PHPUnit configuration, so a PHP deprecation would otherwise pass the suite unnoticed. PHP 8.5 is already in the test matrix.

On a matrix of three sources and nine configurations, the two processors now agree to within one level per channel. The only exception is the antialiased band of the rounded corners, 0.33% of pixels, where two different rasterizers cannot be made identical.

Beyond the suite, the whole surface was replayed under `E_ALL` on 8.2, 8.3, 8.4 and 8.5 in the `phpqa` images: no diagnostic, no failure. ECS, Rector, PHPStan at max, Deptrac and lint are clean, and the baseline needed no new entry.

Two `ConfigurationTest` failures show up when the suite is run through `vendor/bin/phpunit`. They reproduce identically on the `9d8bbaa` base commit and do not occur under the `phpunit-11` the test job runs, so they belong to the local toolchain rather than to this branch.

> [!NOTE]
> That gap is worth knowing for future test contributions, and it is what the third commit is about. Composer resolves PHPUnit 13 into `vendor/`, the test job runs the `phpunit-11` the phpqa image ships, and Rector aligns test code with the former: it rewrote `expectExceptionMessage()` to the `expectExceptionMessageIsOrContains()` spelling PHPUnit 12 introduced, which passes locally and is an undefined method on the whole matrix. `RenameMethodRector` is now skipped over `tests/`, alongside the two notes the Rector configuration already carries for the same reason on the Symfony side. `castor phpunit` is what reproduces the job; `vendor/bin/phpunit` is not.

## What this changes for existing installations

The second commit changes generated bytes. The affected cases, in the order I would worry about them:

- **A non-square source under GD** now produces the whole mark on a transparent band instead of a cropped slice. This is the visible one.
- **A background colour GD used to mis-parse** — any name, any `rgb()` — now produces the colour that was asked for rather than a near black one.
- **A colour neither processor can resolve** now raises an `InvalidArgumentException` instead of quietly rendering something wrong.
- **JPEG** gets larger under GD, smaller under Imagick, and stops depending on the quality of the source.
- **`monochrome` under GD** now does something.
- **Rounded corners** move by about a pixel on the Imagick side, and stop being asymmetric.
- **`gray` and `grey` under Imagick** become the CSS `#808080`.

> [!IMPORTANT]
> The generated file names do not change with any of this. They are hashed from the asset digest and the `Configuration`, neither of which is touched, so a rebuild writes different bytes under the same names. Ordinary deploys are fine; anything caching those URLs at the edge with a long TTL will keep serving the old bytes until it is purged.
