### PR TITLE
Describe the iOS startup images with a Twig template

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -55,6 +55,18 @@ parameters:
 			path: ../src/Dto/Shortcut.php
 
 		-
+			rawMessage: Class SpomkyLabs\PwaBundle\Dto\StartupImageTheme has an uninitialized property $src. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: ../src/Dto/StartupImageTheme.php
+
+		-
+			rawMessage: Class SpomkyLabs\PwaBundle\Dto\StartupImages has an uninitialized property $default. Give it default value or assign it in the constructor.
+			identifier: property.uninitialized
+			count: 1
+			path: ../src/Dto/StartupImages.php
+
+		-
 			rawMessage: Class SpomkyLabs\PwaBundle\Dto\Theme has an uninitialized property $src. Give it default value or assign it in the constructor.
 			identifier: property.uninitialized
 			count: 1

--- a/src/Dto/StartupImageTheme.php
+++ b/src/Dto/StartupImageTheme.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Dto;
+
+use Symfony\Component\Serializer\Attribute\SerializedName;
+
+final class StartupImageTheme
+{
+    public Asset $src;
+
+    #[SerializedName('background_color')]
+    public null|string $backgroundColor = null;
+
+    /**
+     * @var int<1, 50>|null
+     */
+    #[SerializedName('border_radius')]
+    public null|int $borderRadius = null;
+
+    /**
+     * @var int<1, 100>|null
+     */
+    #[SerializedName('image_scale')]
+    public null|int $imageScale = null;
+
+    /**
+     * @var array<string, bool|string>
+     */
+    #[SerializedName('svg_attr')]
+    public array $svgAttributes = [];
+
+    /**
+     * The free-form variables handed to the template, already merged with the ones declared for every
+     * color scheme.
+     *
+     * @var array<string, mixed>
+     */
+    public array $context = [];
+}

--- a/src/Dto/StartupImages.php
+++ b/src/Dto/StartupImages.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Dto;
+
+final class StartupImages
+{
+    public bool $enabled = false;
+
+    /**
+     * The Twig template describing the image. When left null, the image is composited by the image
+     * processor: the source image, centered over the background color.
+     */
+    public null|string $template = null;
+
+    public StartupImageTheme $default;
+
+    public null|StartupImageTheme $dark = null;
+
+    public bool $monochrome = false;
+}

--- a/src/Resources/config/definition/favicons.php
+++ b/src/Resources/config/definition/favicons.php
@@ -162,6 +162,11 @@ return static function (DefinitionConfigurator $definition): void {
         ->end()
         ->booleanNode('use_start_image')
         ->defaultTrue()
+        ->setDeprecated(
+            'spomky-labs/phpwa',
+            '1.6.0',
+            'The "%node%" configuration key is deprecated. Use the "pwa.startup_images.enabled" configuration key instead.'
+        )
         ->info('Use the icon as a start image for the iOS splash screen.')
         ->end()
         ->scalarNode('svg_color')

--- a/src/Resources/config/definition/startup_images.php
+++ b/src/Resources/config/definition/startup_images.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/utils/startup_images.php';
+
+use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
+
+return static function (DefinitionConfigurator $definition): void {
+    $definition->rootNode()
+        ->children()
+        ->arrayNode('startup_images')
+        ->info(
+            'The images iOS shows while the application is starting up. One image is generated per device and orientation.'
+        )
+        ->addDefaultsIfNotSet()
+        ->children()
+        ->booleanNode('enabled')
+        // Left undecided on purpose: the section then follows "favicons.use_start_image", which used to be
+        // the only way to ask for startup images.
+        ->defaultNull()
+        ->info('Whether startup images are generated. Defaults to the value of "favicons.use_start_image".')
+        ->end()
+        ->scalarNode('template')
+        ->defaultNull()
+        ->info(
+            'The Twig template describing the image. When omitted, the source image is simply centered over the background color.'
+        )
+        ->example(['pwa/startup_image.html.twig', '@SpomkyLabsPwa/StartupImage/default.html.twig'])
+        ->end()
+        ->arrayNode('context')
+        ->useAttributeAsKey('name')
+        ->info('Variables handed to the template, whatever the color scheme.')
+        ->example([
+            'subtitle' => 'Your daily companion',
+        ])
+        ->variablePrototype()
+        ->end()
+        ->end()
+        ->append(
+            getStartupImageThemeNode(
+                'default',
+                'The startup image parameters. When used with "dark", these become the light ones.'
+            )
+        )
+        ->append(getStartupImageThemeNode('dark', 'The startup image parameters for the dark color scheme.'))
+        ->end()
+        ->end()
+        ->end();
+};

--- a/src/Resources/config/definition/utils/startup_images.php
+++ b/src/Resources/config/definition/utils/startup_images.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+function getStartupImageThemeNode(string $nodeName, string $info): ArrayNodeDefinition
+{
+    $treeBuilder = new TreeBuilder($nodeName);
+    $node = $treeBuilder->getRootNode();
+    assert($node instanceof ArrayNodeDefinition);
+    $node
+        ->info($info)
+        ->addDefaultsIfNotSet()
+        ->children()
+        ->scalarNode('src')
+        ->defaultNull()
+        ->info(
+            'The path to the image. Can be served by Asset Mapper, an absolute path or a Symfony UX Icon (if the bundle is installed). Falls back to the favicon of the same color scheme.'
+        )
+        ->example(['icon/logo.svg', '/path/to/my/logo.png', 'logos:pwa'])
+        ->end()
+        ->scalarNode('background_color')
+        ->defaultNull()
+        ->info(
+            'The background color of the startup image. Falls back to the favicon one, then to the one declared in the Manifest section.'
+        )
+        ->example(['red', '#f5ef06'])
+        ->end()
+        ->integerNode('border_radius')
+        ->defaultNull()
+        ->min(1)
+        ->max(50)
+        ->info('The border radius of the image. Ignored when a template is used.')
+        ->end()
+        ->integerNode('image_scale')
+        ->defaultNull()
+        ->min(1)
+        ->max(100)
+        ->info(
+            'The scale of the image. Ignored when a template is used: the template is free to size the image as it sees fit.'
+        )
+        ->end()
+        ->arrayNode('svg_attr')
+        ->useAttributeAsKey('name')
+        ->info('Additional attributes to put to the SVG root.')
+        ->variablePrototype()
+        ->end()
+        ->end()
+        ->arrayNode('context')
+        ->useAttributeAsKey('name')
+        ->info('Variables handed to the template for this color scheme only. Merged over the shared ones.')
+        ->example([
+            'subtitle' => 'The dark side of the application',
+        ])
+        ->variablePrototype()
+        ->end()
+        ->end()
+        ->end()
+        ->end();
+
+    return $node;
+}

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -37,9 +37,17 @@ use SpomkyLabs\PwaBundle\Service\ScreenshotGenerator;
 use SpomkyLabs\PwaBundle\Service\ScreenshotUrlGenerator;
 use SpomkyLabs\PwaBundle\Service\ServiceWorkerBuilder;
 use SpomkyLabs\PwaBundle\Service\ServiceWorkerCompiler;
+use SpomkyLabs\PwaBundle\Service\SourceImageResolver;
 use SpomkyLabs\PwaBundle\Service\SpeculationRulesBuilder;
+use SpomkyLabs\PwaBundle\Service\StartupImagesBuilder;
+use SpomkyLabs\PwaBundle\Service\StartupImagesCompiler;
 use SpomkyLabs\PwaBundle\Service\TextDirectionResolver;
 use SpomkyLabs\PwaBundle\ServiceWorkerRule\ServiceWorkerRuleInterface;
+use SpomkyLabs\PwaBundle\StartupImage\ChromeHtmlRenderer;
+use SpomkyLabs\PwaBundle\StartupImage\DeviceCatalog;
+use SpomkyLabs\PwaBundle\StartupImage\HtmlRendererInterface;
+use SpomkyLabs\PwaBundle\StartupImage\IconStartupImageRenderer;
+use SpomkyLabs\PwaBundle\StartupImage\TemplateStartupImageRenderer;
 use SpomkyLabs\PwaBundle\Twig\InstanceOfExtension;
 use SpomkyLabs\PwaBundle\Twig\PwaExtension;
 use SpomkyLabs\PwaBundle\Twig\PwaRuntime;
@@ -48,6 +56,7 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use Symfony\Component\Mime\MimeTypes;
 use Symfony\Component\Panther\Client;
+use Symfony\UX\Icons\IconRendererInterface;
 
 return static function (ContainerConfigurator $configurator): void {
     $container = $configurator->services()
@@ -95,6 +104,35 @@ return static function (ContainerConfigurator $configurator): void {
     ;
     $container->set(FaviconsCompiler::class);
 
+    /* Startup images */
+    $container->set(StartupImagesBuilder::class)
+        ->args([
+            '$config' => param('spomky_labs_pwa.startup_images.config'),
+        ])
+    ;
+    $container->set(DeviceCatalog::class);
+    $container->set(IconStartupImageRenderer::class);
+    $container->set(TemplateStartupImageRenderer::class)
+        ->args([
+            '$twig' => service('twig')->nullOnInvalid(),
+            '$htmlRenderer' => service(HtmlRendererInterface::class)->nullOnInvalid(),
+        ])
+    ;
+    if (class_exists(Client::class) && class_exists(WebDriverDimension::class)) {
+        $container->set(ChromeHtmlRenderer::class)
+            ->args([
+                '$webClient' => service('pwa.web_client')->nullOnInvalid(),
+            ])
+        ;
+        $container->alias(HtmlRendererInterface::class, ChromeHtmlRenderer::class);
+    }
+    $container->set(StartupImagesCompiler::class);
+
+    $container->set(SourceImageResolver::class)
+        ->args([
+            '$iconRenderer' => service(IconRendererInterface::class)->nullOnInvalid(),
+        ])
+    ;
     $container->set(IconResolver::class);
     $container->set(ApplicationIconCompiler::class);
     $container->set(ScreenshotUrlGenerator::class);

--- a/src/Service/FaviconsCompiler.php
+++ b/src/Service/FaviconsCompiler.php
@@ -15,12 +15,9 @@ use SpomkyLabs\PwaBundle\Dto\Favicons;
 use SpomkyLabs\PwaBundle\ImageProcessor\Configuration;
 use SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface;
 use function sprintf;
-use Symfony\Component\AssetMapper\AssetMapperInterface;
-use Symfony\Component\AssetMapper\MappedAsset;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
-use Symfony\UX\Icons\IconRendererInterface;
 
 final class FaviconsCompiler implements FileCompilerInterface, CanLogInterface
 {
@@ -31,8 +28,7 @@ final class FaviconsCompiler implements FileCompilerInterface, CanLogInterface
     public function __construct(
         private readonly null|ImageProcessorInterface $imageProcessor,
         FaviconsBuilder $faviconsBuilder,
-        private readonly AssetMapperInterface $assetMapper,
-        private readonly ?IconRendererInterface $renderer,
+        private readonly SourceImageResolver $sourceImageResolver,
         private readonly BasePathResolver $basePathResolver,
         #[Autowire(param: 'kernel.debug')]
         public readonly bool $debug,
@@ -96,14 +92,12 @@ final class FaviconsCompiler implements FileCompilerInterface, CanLogInterface
                     $size['format'],
                     $theme->backgroundColor,
                     $theme->borderRadius,
-                    $size['imageScale'] ?? $theme->imageScale,
+                    $theme->imageScale,
                     $this->favicons->monochrome
                 );
                 $completeHash = hash('xxh128', $hash . $configuration);
                 $filename = sprintf($size['url'], $size['width'], $size['height'], $completeHash);
-                $media = $hasFixedUrl
-                    ? ($size['media'] ?? null)
-                    : $this->combineMediaQueries($size['media'] ?? null, $sourceInfo['media']);
+                $media = $hasFixedUrl ? null : $this->getColorSchemeMediaQuery($sourceInfo['media']);
 
                 // Two sizes can describe the very same file: the low resolution block declares 72x72 both
                 // as an apple-touch-icon and as an icon, for one identical configuration. Both links are
@@ -152,26 +146,17 @@ final class FaviconsCompiler implements FileCompilerInterface, CanLogInterface
     }
 
     /**
-     * Combines the media query carried by a size with the one of the color scheme it is generated for.
-     *
-     * The two conditions are concatenated as-is: each of them is already a chain of parenthesized media
-     * features, and wrapping the whole in an extra pair of parentheses would turn it into a Media Queries
-     * Level 4 nested condition. Safari only parses that syntax from 16.4 on, and a browser that fails to
-     * parse a media query discards it entirely, together with the startup image it carries.
+     * The condition an icon is declined under, which is the color scheme it is generated for, and nothing
+     * else as long as no dark theme is configured.
      */
-    private function combineMediaQueries(null|string $sizeMedia, null|string $schemeMedia): null|string
+    private function getColorSchemeMediaQuery(null|string $schemeMedia): null|string
     {
         if ($this->favicons->dark === null) {
-            return $sizeMedia;
+            return null;
         }
 
         // The default theme is the light one as soon as a dark theme is defined.
-        $schemeMedia ??= '(prefers-color-scheme: light)';
-        if ($sizeMedia === null) {
-            return $schemeMedia;
-        }
-
-        return $sizeMedia . ' and ' . $schemeMedia;
+        return $schemeMedia ?? '(prefers-color-scheme: light)';
     }
 
     /**
@@ -436,35 +421,12 @@ XML;
      */
     private function getFaviconAsset(Asset $asset, array $attributes): string
     {
-        if (str_starts_with($asset->src, '/')) {
-            return $this->readAssetFile($asset->src);
-        }
-        if ($this->renderer !== null && str_contains($asset->src, ':')) {
-            return $this->renderer->renderIcon($asset->src, $attributes);
-        }
-
-        // Guarded rather than asserted: assertions are compiled out in production, where a missing asset
-        // used to surface as a property read on null from inside this method.
-        $mappedAsset = $this->assetMapper->getAsset($asset->src);
-        if (! $mappedAsset instanceof MappedAsset) {
-            throw new RuntimeException(sprintf('The favicon asset "%s" cannot be found.', $asset->src));
-        }
-
-        return $mappedAsset->content ?? $this->readAssetFile($mappedAsset->sourcePath);
-    }
-
-    private function readAssetFile(string $path): string
-    {
-        $content = @file_get_contents($path);
-        if ($content === false) {
-            throw new RuntimeException(sprintf('The favicon asset "%s" cannot be read.', $path));
-        }
-
-        return $content;
+        return $this->sourceImageResolver->resolve($asset, $attributes)
+            ->content;
     }
 
     /**
-     * @return array{url: string, width: int<1, max>, height: int<1, max>, format: string, mimetype: string, rel: string, imageScale?: int, media?: string, fixedUrl?: bool}[]
+     * @return array{url: string, width: int<1, max>, height: int<1, max>, format: string, mimetype: string, rel: string, fixedUrl?: bool}[]
      */
     private function getFaviconSizes(): array
     {
@@ -524,243 +486,6 @@ XML;
                 'rel' => 'icon',
             ],
         ];
-
-        if ($this->favicons->useStartImage === true) {
-
-            // iOS only shows a startup image whose dimensions match the screen exactly, so an entry is
-            // needed for every distinct point size Apple ships. In portrait the image is
-            // device-width x device-height, in landscape the two are swapped: device-width and
-            // device-height always describe the screen in its natural, portrait orientation.
-            $startupImages = [
-                // iPad Pro 13" (M4)
-                [
-                    'width' => 2064,
-                    'height' => 2752,
-                    'media' => '(device-width: 1032px) and (device-height: 1376px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)',
-                ],
-                [
-                    'width' => 2752,
-                    'height' => 2064,
-                    'media' => '(device-width: 1032px) and (device-height: 1376px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)',
-                ],
-                // iPad Pro 11" (M4)
-                [
-                    'width' => 1668,
-                    'height' => 2420,
-                    'media' => '(device-width: 834px) and (device-height: 1210px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)',
-                ],
-                [
-                    'width' => 2420,
-                    'height' => 1668,
-                    'media' => '(device-width: 834px) and (device-height: 1210px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)',
-                ],
-                [
-                    'width' => 2048,
-                    'height' => 2732,
-                    'media' => '(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)',
-                ],
-                [
-                    'width' => 2732,
-                    'height' => 2048,
-                    'media' => '(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)',
-                ],
-                [
-                    'width' => 1668,
-                    'height' => 2388,
-                    'media' => '(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)',
-                ],
-                [
-                    'width' => 2388,
-                    'height' => 1668,
-                    'media' => '(device-width: 834px) and (device-height: 1194px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)',
-                ],
-                [
-                    'width' => 1536,
-                    'height' => 2048,
-                    'media' => '(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)',
-                ],
-                [
-                    'width' => 2048,
-                    'height' => 1536,
-                    'media' => '(device-width: 768px) and (device-height: 1024px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)',
-                ],
-                [
-                    'width' => 1640,
-                    'height' => 2360,
-                    'media' => '(device-width: 820px) and (device-height: 1180px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)',
-                ],
-                [
-                    'width' => 2360,
-                    'height' => 1640,
-                    'media' => '(device-width: 820px) and (device-height: 1180px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)',
-                ],
-                [
-                    'width' => 1668,
-                    'height' => 2224,
-                    'media' => '(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)',
-                ],
-                [
-                    'width' => 2224,
-                    'height' => 1668,
-                    'media' => '(device-width: 834px) and (device-height: 1112px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)',
-                ],
-                [
-                    'width' => 1620,
-                    'height' => 2160,
-                    'media' => '(device-width: 810px) and (device-height: 1080px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)',
-                ],
-                [
-                    'width' => 2160,
-                    'height' => 1620,
-                    'media' => '(device-width: 810px) and (device-height: 1080px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)',
-                ],
-                [
-                    'width' => 1488,
-                    'height' => 2266,
-                    'media' => '(device-width: 744px) and (device-height: 1133px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)',
-                ],
-                [
-                    'width' => 2266,
-                    'height' => 1488,
-                    'media' => '(device-width: 744px) and (device-height: 1133px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)',
-                ],
-                [
-                    'width' => 1320,
-                    'height' => 2868,
-                    'media' => '(device-width: 440px) and (device-height: 956px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)',
-                ],
-                [
-                    'width' => 2868,
-                    'height' => 1320,
-                    'media' => '(device-width: 440px) and (device-height: 956px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)',
-                ],
-                [
-                    'width' => 1206,
-                    'height' => 2622,
-                    'media' => '(device-width: 402px) and (device-height: 874px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)',
-                ],
-                [
-                    'width' => 2622,
-                    'height' => 1206,
-                    'media' => '(device-width: 402px) and (device-height: 874px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)',
-                ],
-                [
-                    'width' => 1290,
-                    'height' => 2796,
-                    'media' => '(device-width: 430px) and (device-height: 932px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)',
-                ],
-                [
-                    'width' => 2796,
-                    'height' => 1290,
-                    'media' => '(device-width: 430px) and (device-height: 932px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)',
-                ],
-                [
-                    'width' => 1179,
-                    'height' => 2556,
-                    'media' => '(device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)',
-                ],
-                [
-                    'width' => 2556,
-                    'height' => 1179,
-                    'media' => '(device-width: 393px) and (device-height: 852px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)',
-                ],
-                [
-                    'width' => 1170,
-                    'height' => 2532,
-                    'media' => '(device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)',
-                ],
-                [
-                    'width' => 2532,
-                    'height' => 1170,
-                    'media' => '(device-width: 390px) and (device-height: 844px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)',
-                ],
-                [
-                    'width' => 1284,
-                    'height' => 2778,
-                    'media' => '(device-width: 428px) and (device-height: 926px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)',
-                ],
-                [
-                    'width' => 2778,
-                    'height' => 1284,
-                    'media' => '(device-width: 428px) and (device-height: 926px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)',
-                ],
-                [
-                    'width' => 1125,
-                    'height' => 2436,
-                    'media' => '(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)',
-                ],
-                [
-                    'width' => 2436,
-                    'height' => 1125,
-                    'media' => '(device-width: 375px) and (device-height: 812px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)',
-                ],
-                [
-                    'width' => 1242,
-                    'height' => 2688,
-                    'media' => '(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)',
-                ],
-                [
-                    'width' => 2688,
-                    'height' => 1242,
-                    'media' => '(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)',
-                ],
-                [
-                    'width' => 828,
-                    'height' => 1792,
-                    'media' => '(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)',
-                ],
-                [
-                    'width' => 1792,
-                    'height' => 828,
-                    'media' => '(device-width: 414px) and (device-height: 896px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)',
-                ],
-                [
-                    'width' => 1242,
-                    'height' => 2208,
-                    'media' => '(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait)',
-                ],
-                [
-                    'width' => 2208,
-                    'height' => 1242,
-                    'media' => '(device-width: 414px) and (device-height: 736px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape)',
-                ],
-                [
-                    'width' => 750,
-                    'height' => 1334,
-                    'media' => '(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)',
-                ],
-                [
-                    'width' => 1334,
-                    'height' => 750,
-                    'media' => '(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)',
-                ],
-                [
-                    'width' => 640,
-                    'height' => 1136,
-                    'media' => '(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)',
-                ],
-                [
-                    'width' => 1136,
-                    'height' => 640,
-                    'media' => '(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)',
-                ],
-            ];
-            foreach ($startupImages as $startupImage) {
-                ['width' => $width, 'height' => $height, 'media' => $media] = $startupImage;
-                $diagonal = sqrt($width ** 2 + $height ** 2);
-                $scale = 30 + 10 * exp(-$diagonal / 1500);
-                $sizes[] = [
-                    'url' => '/pwa/start-image-%dx%d-%s.png',
-                    'width' => $width,
-                    'height' => $height,
-                    'format' => 'png',
-                    'mimetype' => 'image/png',
-                    'rel' => 'apple-touch-startup-image',
-                    'imageScale' => (int) $scale,
-                    'media' => $media,
-                ];
-            }
-        }
 
         if ($this->favicons->lowResolution === true) {
             $sizes = [

--- a/src/Service/SourceImage.php
+++ b/src/Service/SourceImage.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Service;
+
+use function sprintf;
+
+/**
+ * The raw bytes of a configured image source, together with the media type they were recognised as.
+ */
+final readonly class SourceImage
+{
+    public function __construct(
+        public string $content,
+        public string $mimeType,
+    ) {
+    }
+
+    public static function create(string $content, string $mimeType): self
+    {
+        return new self($content, $mimeType);
+    }
+
+    public function isSvg(): bool
+    {
+        return $this->mimeType === 'image/svg+xml';
+    }
+
+    /**
+     * The source inlined as a data URI, so that a template can reference it without the renderer having to
+     * resolve any path of its own.
+     */
+    public function getDataUri(): string
+    {
+        return sprintf('data:%s;base64,%s', $this->mimeType, base64_encode($this->content));
+    }
+}

--- a/src/Service/SourceImageResolver.php
+++ b/src/Service/SourceImageResolver.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Service;
+
+use function is_string;
+use const PATHINFO_EXTENSION;
+use RuntimeException;
+use SpomkyLabs\PwaBundle\Dto\Asset;
+use function sprintf;
+use function str_starts_with;
+use Symfony\Component\AssetMapper\AssetMapperInterface;
+use Symfony\Component\AssetMapper\MappedAsset;
+use Symfony\Component\Mime\MimeTypes;
+use Symfony\UX\Icons\IconRendererInterface;
+
+/**
+ * Reads a configured image source, whatever it is declared as: an Asset Mapper logical path, an absolute
+ * path, or a Symfony UX Icon name.
+ */
+final readonly class SourceImageResolver
+{
+    /**
+     * @var array<string, string>
+     */
+    private const MAGIC_NUMBERS = [
+        "\x89PNG\r\n\x1a\n" => 'image/png',
+        "\xff\xd8\xff" => 'image/jpeg',
+        'GIF87a' => 'image/gif',
+        'GIF89a' => 'image/gif',
+    ];
+
+    public function __construct(
+        private AssetMapperInterface $assetMapper,
+        private null|IconRendererInterface $iconRenderer,
+    ) {
+    }
+
+    /**
+     * @param array<string, bool|string> $svgAttributes
+     */
+    public function resolve(Asset $asset, array $svgAttributes = []): SourceImage
+    {
+        $content = $this->getContent($asset, $svgAttributes);
+
+        return SourceImage::create($content, $this->detectMimeType($asset->src, $content));
+    }
+
+    /**
+     * @param array<string, bool|string> $svgAttributes
+     */
+    private function getContent(Asset $asset, array $svgAttributes): string
+    {
+        if (str_starts_with($asset->src, '/')) {
+            return $this->read($asset->src);
+        }
+        if ($this->iconRenderer !== null && str_contains($asset->src, ':')) {
+            return $this->iconRenderer->renderIcon($asset->src, $svgAttributes);
+        }
+
+        // Guarded rather than asserted: assertions are compiled out in production, where a missing asset
+        // used to surface as a property read on null from inside this method.
+        $mappedAsset = $this->assetMapper->getAsset($asset->src);
+        if (! $mappedAsset instanceof MappedAsset) {
+            throw new RuntimeException(sprintf('The image source "%s" cannot be found.', $asset->src));
+        }
+
+        return $mappedAsset->content ?? $this->read($mappedAsset->sourcePath);
+    }
+
+    private function read(string $path): string
+    {
+        $content = @file_get_contents($path);
+        if ($content === false) {
+            throw new RuntimeException(sprintf('The image source "%s" cannot be read.', $path));
+        }
+
+        return $content;
+    }
+
+    /**
+     * The magic numbers are looked at before the file name: a UX Icon has no extension at all, and an
+     * Asset Mapper path can very well point at a ".svg" holding something else after a build step.
+     */
+    private function detectMimeType(string $src, string $content): string
+    {
+        foreach (self::MAGIC_NUMBERS as $signature => $mimeType) {
+            if (str_starts_with($content, $signature)) {
+                return $mimeType;
+            }
+        }
+        if (str_starts_with($content, 'RIFF') && str_contains(substr($content, 0, 16), 'WEBP')) {
+            return 'image/webp';
+        }
+        if (str_contains(substr($content, 0, 1024), '<svg')) {
+            return 'image/svg+xml';
+        }
+
+        return $this->guessFromExtension($src) ?? 'application/octet-stream';
+    }
+
+    private function guessFromExtension(string $src): null|string
+    {
+        if (! class_exists(MimeTypes::class)) {
+            return null;
+        }
+        $extension = pathinfo($src, PATHINFO_EXTENSION);
+        if (! is_string($extension) || $extension === '') {
+            return null;
+        }
+
+        return MimeTypes::getDefault()->getMimeTypes($extension)[0] ?? null;
+    }
+}

--- a/src/Service/StartupImagesBuilder.php
+++ b/src/Service/StartupImagesBuilder.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Service;
+
+use function assert;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use SpomkyLabs\PwaBundle\Dto\StartupImages;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+final class StartupImagesBuilder implements CanLogInterface
+{
+    private null|StartupImages $startupImages = null;
+
+    private LoggerInterface $logger;
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function __construct(
+        private readonly DenormalizerInterface $denormalizer,
+        private readonly array $config,
+    ) {
+        $this->logger = new NullLogger();
+    }
+
+    public function create(): StartupImages
+    {
+        if ($this->startupImages === null) {
+            $this->logger->debug('Creating startup images.', [
+                'config' => $this->config,
+            ]);
+            $result = $this->denormalizer->denormalize($this->config, StartupImages::class);
+            assert($result instanceof StartupImages);
+            $this->startupImages = $result;
+            $this->logger->debug('Startup images created.', [
+                'startupImages' => $this->startupImages,
+            ]);
+        }
+
+        return $this->startupImages;
+    }
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+    }
+}

--- a/src/Service/StartupImagesCompiler.php
+++ b/src/Service/StartupImagesCompiler.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Service;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use SpomkyLabs\PwaBundle\Dto\StartupImages;
+use SpomkyLabs\PwaBundle\Dto\StartupImageTheme;
+use SpomkyLabs\PwaBundle\StartupImage\ColorScheme;
+use SpomkyLabs\PwaBundle\StartupImage\DeviceCatalog;
+use SpomkyLabs\PwaBundle\StartupImage\IconStartupImageRenderer;
+use SpomkyLabs\PwaBundle\StartupImage\StartupImageDefinition;
+use SpomkyLabs\PwaBundle\StartupImage\StartupImageRendererInterface;
+use SpomkyLabs\PwaBundle\StartupImage\TemplateStartupImageRenderer;
+use function sprintf;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Generates the images iOS shows while the application is starting up.
+ *
+ * Every device is declared in both orientations, and once more per color scheme when a dark variant is
+ * configured. What the image is made of is left to a renderer: the source image centered over the
+ * background color, or a Twig template painted by a browser.
+ */
+final class StartupImagesCompiler implements FileCompilerInterface, CanLogInterface
+{
+    private LoggerInterface $logger;
+
+    private readonly StartupImages $startupImages;
+
+    public function __construct(
+        StartupImagesBuilder $startupImagesBuilder,
+        private readonly DeviceCatalog $deviceCatalog,
+        private readonly IconStartupImageRenderer $iconRenderer,
+        private readonly TemplateStartupImageRenderer $templateRenderer,
+        private readonly BasePathResolver $basePathResolver,
+        #[Autowire(param: 'kernel.debug')]
+        private readonly bool $debug,
+    ) {
+        $this->startupImages = $startupImagesBuilder->create();
+        $this->logger = new NullLogger();
+    }
+
+    /**
+     * @return iterable<string, Data>
+     */
+    public function getFiles(): iterable
+    {
+        $this->logger->debug('Compiling startup images.', [
+            'startupImages' => $this->startupImages,
+        ]);
+        if ($this->startupImages->enabled === false) {
+            $this->logger->debug('Startup images are disabled.');
+            return [];
+        }
+
+        $renderer = $this->getRenderer();
+        foreach ($this->getThemes() as $colorSchemeValue => $theme) {
+            $colorScheme = ColorScheme::from($colorSchemeValue);
+            foreach ($this->deviceCatalog->allOrientations() as ['device' => $device, 'orientation' => $orientation]) {
+                $definition = StartupImageDefinition::create($theme, $colorScheme, $device, $orientation);
+                $url = sprintf(
+                    '/pwa/start-image-%dx%d-%s.png',
+                    $definition->width,
+                    $definition->height,
+                    $renderer->hash($definition)
+                );
+
+                yield $url => Data::create(
+                    $url,
+                    fn (): string => $renderer->render($definition),
+                    $this->getHeaders(),
+                    $this->getLink($url, $definition),
+                );
+            }
+        }
+
+        $this->logger->debug('Startup images created.');
+    }
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * No template means the historical image, which asks nothing of the application beyond the image
+     * processor. A template is the opposite: it was configured on purpose, so a missing requirement is
+     * reported rather than worked around.
+     */
+    private function getRenderer(): StartupImageRendererInterface
+    {
+        if ($this->startupImages->template === null) {
+            return $this->iconRenderer;
+        }
+        $reason = $this->templateRenderer->getUnavailabilityReason();
+        if ($reason !== null) {
+            throw new RuntimeException($reason);
+        }
+
+        return $this->templateRenderer;
+    }
+
+    /**
+     * @return array<string, StartupImageTheme>
+     */
+    private function getThemes(): array
+    {
+        $themes = [
+            ColorScheme::LIGHT->value => $this->startupImages->default,
+        ];
+        if ($this->startupImages->dark !== null) {
+            $themes[ColorScheme::DARK->value] = $this->startupImages->dark;
+        }
+
+        return $themes;
+    }
+
+    private function getLink(string $url, StartupImageDefinition $definition): string
+    {
+        return sprintf(
+            '<link rel="apple-touch-startup-image" sizes="%dx%d" type="image/png" href="%s" media="%s">',
+            $definition->width,
+            $definition->height,
+            $this->basePathResolver->prefix($url),
+            $this->getMediaQuery($definition),
+        );
+    }
+
+    /**
+     * The device condition and the color scheme one are concatenated as-is: each of them is already a
+     * chain of parenthesized media features, and wrapping the whole in an extra pair of parentheses would
+     * turn it into a Media Queries Level 4 nested condition. Safari only parses that syntax from 16.4 on,
+     * and a browser that fails to parse a media query discards it entirely, together with the startup
+     * image it carries.
+     */
+    private function getMediaQuery(StartupImageDefinition $definition): string
+    {
+        if ($this->startupImages->dark === null) {
+            return $definition->mediaQuery();
+        }
+
+        return $definition->mediaQuery() . ' and ' . $definition->colorScheme->mediaQuery();
+    }
+
+    /**
+     * @return array<string, string|bool>
+     */
+    private function getHeaders(): array
+    {
+        if (! $this->debug) {
+            return [];
+        }
+
+        return [
+            'Cache-Control' => 'public, max-age=604800, immutable',
+            'Content-Type' => 'image/png',
+            'X-Pwa-Dev' => true,
+        ];
+    }
+}

--- a/src/SpomkyLabsPwaBundle.php
+++ b/src/SpomkyLabsPwaBundle.php
@@ -113,6 +113,14 @@ final class SpomkyLabsPwaBundle extends AbstractBundle
         $faviconsConfig = $this->applyManifestBackgroundColor($faviconsConfig, $manifestConfig);
         $builder->setParameter('spomky_labs_pwa.favicons.config', $faviconsConfig);
 
+        /* Startup images */
+        /** @var array<string, mixed> $startupImagesConfig */
+        $startupImagesConfig = $config['startup_images'] ?? [];
+        $builder->setParameter(
+            'spomky_labs_pwa.startup_images.config',
+            $this->prepareStartupImagesConfig($startupImagesConfig, $faviconsConfig, $manifestConfig)
+        );
+
         /* Service Worker */
         $builder->setParameter('spomky_labs_pwa.sw.enabled', $serviceWorkerConfig['enabled']);
         $builder->setParameter('spomky_labs_pwa.sw.public_url', $serviceWorkerConfig['dest'] ?? null);
@@ -167,6 +175,59 @@ final class SpomkyLabsPwaBundle extends AbstractBundle
             $imageProcessor,
             $extension
         ));
+    }
+
+    /**
+     * The startup images used to be a favicon setting, and they still borrow from it whatever they have
+     * not been told: whether to generate them at all, which image to draw, and the colors to draw it on.
+     *
+     * @param array<string, mixed> $config
+     * @param array<string, mixed> $faviconsConfig
+     * @param array<string, mixed> $manifestConfig
+     *
+     * @return array<string, mixed>
+     */
+    private function prepareStartupImagesConfig(array $config, array $faviconsConfig, array $manifestConfig): array
+    {
+        if (($config['enabled'] ?? null) === null) {
+            $config['enabled'] = ($faviconsConfig['enabled'] ?? false) === true
+                && ($faviconsConfig['use_start_image'] ?? true) === true;
+        }
+        /** @var array<string, mixed> $sharedContext */
+        $sharedContext = $config['context'] ?? [];
+        $config['monochrome'] = $faviconsConfig['monochrome'] ?? false;
+
+        foreach (['default', 'dark'] as $themeName) {
+            /** @var array<string, mixed> $theme */
+            $theme = $config[$themeName] ?? [];
+            $favicon = $faviconsConfig[$themeName] ?? null;
+            $favicon = is_array($favicon) ? $favicon : [];
+
+            $theme['src'] ??= $favicon['src'] ?? null;
+            if ($theme['src'] === null) {
+                // A color scheme nobody described an image for is simply not declined.
+                unset($config[$themeName]);
+                continue;
+            }
+            $theme['background_color'] ??= $favicon['background_color'] ?? $manifestConfig['background_color'] ?? null;
+            $theme['border_radius'] ??= $favicon['border_radius'] ?? null;
+            $theme['image_scale'] ??= $favicon['image_scale'] ?? null;
+            if (($theme['svg_attr'] ?? []) === []) {
+                $theme['svg_attr'] = $favicon['svg_attr'] ?? [];
+            }
+            /** @var array<string, mixed> $themeContext */
+            $themeContext = $theme['context'] ?? [];
+            $theme['context'] = [...$sharedContext, ...$themeContext];
+
+            $config[$themeName] = $theme;
+        }
+        unset($config['context']);
+
+        if (! isset($config['default'])) {
+            $config['enabled'] = false;
+        }
+
+        return $config;
     }
 
     /**

--- a/src/StartupImage/ChromeHtmlRenderer.php
+++ b/src/StartupImage/ChromeHtmlRenderer.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\StartupImage;
+
+use Facebook\WebDriver\WebDriverDimension;
+use function function_exists;
+use function is_array;
+use function is_int;
+use function is_scalar;
+use RuntimeException;
+use function sprintf;
+use function strlen;
+use Symfony\Component\Panther\Client;
+use Throwable;
+
+/**
+ * Paints the document with a headless Chrome, driven by Panther.
+ *
+ * The browser is started on the first capture and reused for all the others: there are more than eighty
+ * images to produce for a single application, and a browser start dwarfs the capture itself.
+ */
+final class ChromeHtmlRenderer implements HtmlRendererInterface
+{
+    private null|Client $client = null;
+
+    public function __construct(
+        private readonly null|Client $webClient = null,
+    ) {
+    }
+
+    public function __destruct()
+    {
+        $this->close();
+    }
+
+    public function capture(string $html, int $width, int $height): string
+    {
+        $path = sprintf('%s/pwa-startup-%s.html', sys_get_temp_dir(), hash('xxh128', $html));
+        if (file_put_contents($path, $html) === false) {
+            throw new RuntimeException(sprintf('Unable to write the startup image document to "%s".', $path));
+        }
+
+        try {
+            $client = $this->getClient();
+            $client->request('GET', 'file://' . $path);
+            $this->resizeViewport($client, $width, $height);
+            $screenshot = $client->takeScreenshot();
+        } catch (Throwable $exception) {
+            // Panther and the WebDriver stack report a missing or mismatched driver from deep inside
+            // themselves. The application asked for a template, so it is told what that costs.
+            throw new RuntimeException(sprintf(
+                'Unable to paint a startup image with a headless browser: %s. A Chrome driver matching the installed Chrome is needed to render the startup image template; "vendor/bin/bdi detect drivers" installs one, and PANTHER_CHROME_DRIVER_BINARY points at an existing one.',
+                $exception->getMessage()
+            ), 0, $exception);
+        } finally {
+            @unlink($path);
+        }
+
+        $this->assertSize($screenshot, $width, $height);
+
+        return $screenshot;
+    }
+
+    public function close(): void
+    {
+        if ($this->client === null) {
+            return;
+        }
+        try {
+            $this->client->quit();
+        } catch (Throwable) {
+            // The browser is already gone, which is precisely what was being asked for.
+        }
+        $this->client = null;
+    }
+
+    /**
+     * The window is sized, then the viewport it actually yields is measured and the difference given back.
+     * Chrome sizes the *window*, and whatever it paints around the page — a scrollbar, a headless shell
+     * border — is taken out of the page's share of it.
+     */
+    private function resizeViewport(Client $client, int $width, int $height): void
+    {
+        $window = $client->manage()
+            ->window();
+        $window->setSize(new WebDriverDimension($width, $height));
+
+        $inner = $client->executeScript('return [window.innerWidth, window.innerHeight];');
+        if (! is_array($inner) || ! isset($inner[0], $inner[1]) || ! is_numeric($inner[0]) || ! is_numeric(
+            $inner[1]
+        )) {
+            return;
+        }
+        $horizontalLoss = $width - (int) $inner[0];
+        $verticalLoss = $height - (int) $inner[1];
+        if ($horizontalLoss === 0 && $verticalLoss === 0) {
+            return;
+        }
+
+        $window->setSize(new WebDriverDimension($width + $horizontalLoss, $height + $verticalLoss));
+    }
+
+    /**
+     * Reads the dimensions straight out of the PNG header, so that a browser that could not honour the
+     * requested window size is reported here rather than by iOS silently dropping the image.
+     */
+    private function assertSize(string $screenshot, int $width, int $height): void
+    {
+        if (strlen($screenshot) < 24 || ! str_starts_with($screenshot, "\x89PNG\r\n\x1a\n")) {
+            throw new RuntimeException('The browser did not return a PNG screenshot.');
+        }
+        /** @var array{width: int, height: int} $header */
+        $header = unpack('Nwidth/Nheight', substr($screenshot, 16, 8));
+        if ($header['width'] === $width && $header['height'] === $height) {
+            return;
+        }
+
+        throw new RuntimeException(sprintf(
+            'The browser produced a %dx%d startup image where %dx%d was requested. iOS only shows an image whose dimensions match the screen exactly. Make sure the browser runs headless, so that the window is not capped by the display.',
+            $header['width'],
+            $header['height'],
+            $width,
+            $height,
+        ));
+    }
+
+    private function getClient(): Client
+    {
+        if ($this->client !== null) {
+            return $this->client;
+        }
+        if ($this->webClient !== null) {
+            return $this->client = clone $this->webClient;
+        }
+
+        $driver = $this->getEnv('PANTHER_CHROME_DRIVER_BINARY');
+
+        return $this->client = Client::createChromeClient(
+            $driver,
+            $this->getArguments(),
+            [
+                'port' => $this->getAvailablePort(),
+                'capabilities' => [
+                    'acceptInsecureCerts' => true,
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getArguments(): array
+    {
+        $arguments = [];
+        if ($this->getEnv('PANTHER_NO_HEADLESS') === null) {
+            $arguments[] = '--headless';
+            $arguments[] = '--disable-gpu';
+        }
+        if ($this->getEnv('PANTHER_NO_SANDBOX') !== null || $this->getEnv('HAS_JOSH_K_SEAL_OF_APPROVAL') !== null) {
+            $arguments[] = '--no-sandbox';
+        }
+        // A scrollbar would eat into the viewport, and show up on the image itself.
+        $arguments[] = '--hide-scrollbars';
+        // The document is written to the temporary directory and loaded over file://, so that no web
+        // server is needed to compile the images.
+        $arguments[] = '--allow-file-access-from-files';
+
+        $extra = $this->getEnv('PANTHER_CHROME_ARGUMENTS');
+        if ($extra !== null) {
+            $arguments = [...$arguments, ...explode(' ', $extra)];
+        }
+
+        return $arguments;
+    }
+
+    private function getEnv(string $name): null|string
+    {
+        $value = $_SERVER[$name] ?? $_ENV[$name] ?? null;
+        if ($value === null || $value === false || $value === '') {
+            return null;
+        }
+
+        return is_scalar($value) ? (string) $value : null;
+    }
+
+    private function getAvailablePort(): int
+    {
+        if (! function_exists('socket_create_listen')) {
+            return random_int(9000, 9999);
+        }
+
+        $socket = socket_create_listen(0);
+        if ($socket === false) {
+            return random_int(9000, 9999);
+        }
+        $port = null;
+        socket_getsockname($socket, $address, $port);
+        socket_close($socket);
+
+        return is_int($port) ? $port : random_int(9000, 9999);
+    }
+}

--- a/src/StartupImage/ColorScheme.php
+++ b/src/StartupImage/ColorScheme.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\StartupImage;
+
+use function sprintf;
+
+enum ColorScheme: string
+{
+    case LIGHT = 'light';
+
+    case DARK = 'dark';
+
+    public function mediaQuery(): string
+    {
+        return sprintf('(prefers-color-scheme: %s)', $this->value);
+    }
+}

--- a/src/StartupImage/Device.php
+++ b/src/StartupImage/Device.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\StartupImage;
+
+use function assert;
+use function sprintf;
+
+/**
+ * One iOS device, described the way its media query describes it: "device-width" and "device-height" always
+ * measure the screen in its natural, portrait orientation, in CSS pixels. The landscape image of a device is
+ * therefore the very same numbers, swapped.
+ */
+final readonly class Device
+{
+    public function __construct(
+        public string $name,
+        public int $width,
+        public int $height,
+        public int $pixelRatio,
+    ) {
+    }
+
+    public static function create(string $name, int $width, int $height, int $pixelRatio): self
+    {
+        return new self($name, $width, $height, $pixelRatio);
+    }
+
+    /**
+     * @return int<1, max>
+     */
+    public function pixelWidth(Orientation $orientation): int
+    {
+        $side = $orientation === Orientation::PORTRAIT ? $this->width : $this->height;
+        $pixels = $side * $this->pixelRatio;
+        assert($pixels >= 1);
+
+        return $pixels;
+    }
+
+    /**
+     * @return int<1, max>
+     */
+    public function pixelHeight(Orientation $orientation): int
+    {
+        $side = $orientation === Orientation::PORTRAIT ? $this->height : $this->width;
+        $pixels = $side * $this->pixelRatio;
+        assert($pixels >= 1);
+
+        return $pixels;
+    }
+
+    public function mediaQuery(Orientation $orientation): string
+    {
+        return sprintf(
+            '(device-width: %dpx) and (device-height: %dpx) and (-webkit-device-pixel-ratio: %d) and (orientation: %s)',
+            $this->width,
+            $this->height,
+            $this->pixelRatio,
+            $orientation->value,
+        );
+    }
+}

--- a/src/StartupImage/DeviceCatalog.php
+++ b/src/StartupImage/DeviceCatalog.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\StartupImage;
+
+/**
+ * The devices a startup image is generated for.
+ *
+ * iOS only shows a startup image whose dimensions match the screen exactly, so an entry is needed for every
+ * distinct point size Apple ships. Two devices sharing a point size and a pixel ratio are one entry here:
+ * their media queries would be identical, and the second image would never be picked.
+ */
+final readonly class DeviceCatalog
+{
+    /**
+     * @return list<Device>
+     */
+    public function all(): array
+    {
+        return [
+            // iPads
+            Device::create('iPad Pro 13" (M4)', 1032, 1376, 2),
+            Device::create('iPad Pro 11" (M4)', 834, 1210, 2),
+            Device::create('iPad Pro 12.9"', 1024, 1366, 2),
+            Device::create('iPad Pro 11"', 834, 1194, 2),
+            Device::create('iPad Pro 10.5"', 834, 1112, 2),
+            Device::create('iPad Air 10.9"', 820, 1180, 2),
+            Device::create('iPad 10.2"', 810, 1080, 2),
+            Device::create('iPad mini 8.3"', 744, 1133, 2),
+            Device::create('iPad 9.7"', 768, 1024, 2),
+
+            // iPhones
+            Device::create('iPhone 16 Pro Max', 440, 956, 3),
+            Device::create('iPhone 16 Pro', 402, 874, 3),
+            Device::create('iPhone 15 Pro Max', 430, 932, 3),
+            Device::create('iPhone 15 Pro', 393, 852, 3),
+            Device::create('iPhone 14 Plus', 428, 926, 3),
+            Device::create('iPhone 14', 390, 844, 3),
+            Device::create('iPhone 11 Pro Max', 414, 896, 3),
+            Device::create('iPhone 11', 414, 896, 2),
+            Device::create('iPhone 11 Pro', 375, 812, 3),
+            Device::create('iPhone 8 Plus', 414, 736, 3),
+            Device::create('iPhone 8', 375, 667, 2),
+            Device::create('iPhone SE', 320, 568, 2),
+        ];
+    }
+
+    /**
+     * @return iterable<array{device: Device, orientation: Orientation}>
+     */
+    public function allOrientations(): iterable
+    {
+        foreach ($this->all() as $device) {
+            foreach (Orientation::cases() as $orientation) {
+                yield [
+                    'device' => $device,
+                    'orientation' => $orientation,
+                ];
+            }
+        }
+    }
+}

--- a/src/StartupImage/HtmlRendererInterface.php
+++ b/src/StartupImage/HtmlRendererInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\StartupImage;
+
+interface HtmlRendererInterface
+{
+    /**
+     * Paints an HTML document and returns the PNG bytes of a viewport exactly $width x $height device
+     * pixels wide. iOS discards a startup image whose dimensions do not match the screen to the pixel, so
+     * an implementation that cannot honour the requested size shall throw rather than return a fitting-ish
+     * image.
+     *
+     * @param int<1, max> $width
+     * @param int<1, max> $height
+     */
+    public function capture(string $html, int $width, int $height): string;
+}

--- a/src/StartupImage/IconStartupImageRenderer.php
+++ b/src/StartupImage/IconStartupImageRenderer.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\StartupImage;
+
+use RuntimeException;
+use function spl_object_id;
+use SpomkyLabs\PwaBundle\Dto\StartupImages;
+use SpomkyLabs\PwaBundle\Dto\StartupImageTheme;
+use SpomkyLabs\PwaBundle\ImageProcessor\Configuration;
+use SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface;
+use SpomkyLabs\PwaBundle\Service\SourceImageResolver;
+use SpomkyLabs\PwaBundle\Service\StartupImagesBuilder;
+
+/**
+ * The historical rendering: the source image, scaled down and centered over the background color.
+ *
+ * It is what a startup image looks like when no template is configured, and it asks nothing more of the
+ * application than the image processor the icons already need.
+ */
+final class IconStartupImageRenderer implements StartupImageRendererInterface
+{
+    private readonly StartupImages $startupImages;
+
+    /**
+     * @var array<int, string>
+     */
+    private array $contents = [];
+
+    public function __construct(
+        private readonly null|ImageProcessorInterface $imageProcessor,
+        private readonly SourceImageResolver $sourceImageResolver,
+        StartupImagesBuilder $startupImagesBuilder,
+    ) {
+        $this->startupImages = $startupImagesBuilder->create();
+    }
+
+    public function hash(StartupImageDefinition $definition): string
+    {
+        return hash('xxh128', $this->getSourceHash($definition->theme) . $this->getConfiguration($definition));
+    }
+
+    public function render(StartupImageDefinition $definition): string
+    {
+        if ($this->imageProcessor === null) {
+            throw new RuntimeException(
+                'Unable to render the startup images: no image processor is available. Set "pwa.image_processor", or describe the images with a template.'
+            );
+        }
+
+        return $this->imageProcessor->process(
+            $this->getContent($definition->theme),
+            null,
+            null,
+            null,
+            $this->getConfiguration($definition)
+        );
+    }
+
+    private function getConfiguration(StartupImageDefinition $definition): Configuration
+    {
+        return Configuration::create(
+            $definition->width,
+            $definition->height,
+            'png',
+            $definition->theme->backgroundColor,
+            $definition->theme->borderRadius,
+            $this->getImageScale($definition),
+            $this->startupImages->monochrome,
+        );
+    }
+
+    /**
+     * The bigger the screen, the smaller the share of it the image takes: a logo scaled to a third of an
+     * iPad screen reads as a poster, where the very same share of an iPhone SE screen reads as an icon.
+     */
+    private function getImageScale(StartupImageDefinition $definition): int
+    {
+        $diagonal = sqrt($definition->width ** 2 + $definition->height ** 2);
+
+        return (int) (30 + 10 * exp(-$diagonal / 1500));
+    }
+
+    private function getSourceHash(StartupImageTheme $theme): string
+    {
+        return hash('xxh128', $this->getContent($theme));
+    }
+
+    private function getContent(StartupImageTheme $theme): string
+    {
+        return $this->contents[spl_object_id($theme)] ??= $this->sourceImageResolver->resolve(
+            $theme->src,
+            $theme->svgAttributes
+        )->content;
+    }
+}

--- a/src/StartupImage/Orientation.php
+++ b/src/StartupImage/Orientation.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\StartupImage;
+
+enum Orientation: string
+{
+    case PORTRAIT = 'portrait';
+
+    case LANDSCAPE = 'landscape';
+}

--- a/src/StartupImage/StartupImageDefinition.php
+++ b/src/StartupImage/StartupImageDefinition.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\StartupImage;
+
+use SpomkyLabs\PwaBundle\Dto\StartupImageTheme;
+
+/**
+ * One image to produce: a device, an orientation and the color scheme they are declined for.
+ */
+final readonly class StartupImageDefinition
+{
+    /**
+     * @param int<1, max> $width
+     * @param int<1, max> $height
+     */
+    private function __construct(
+        public StartupImageTheme $theme,
+        public ColorScheme $colorScheme,
+        public Device $device,
+        public Orientation $orientation,
+        public int $width,
+        public int $height,
+    ) {
+    }
+
+    public static function create(
+        StartupImageTheme $theme,
+        ColorScheme $colorScheme,
+        Device $device,
+        Orientation $orientation,
+    ): self {
+        return new self(
+            $theme,
+            $colorScheme,
+            $device,
+            $orientation,
+            $device->pixelWidth($orientation),
+            $device->pixelHeight($orientation),
+        );
+    }
+
+    public function mediaQuery(): string
+    {
+        return $this->device->mediaQuery($this->orientation);
+    }
+}

--- a/src/StartupImage/StartupImageRendererInterface.php
+++ b/src/StartupImage/StartupImageRendererInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\StartupImage;
+
+interface StartupImageRendererInterface
+{
+    /**
+     * The hash the generated file name is built on. Two definitions producing the very same bytes shall
+     * hash alike, and any change to what shapes the rendering shall change it: the file is served as
+     * immutable, so a stale hash is a stale image in every cache along the way.
+     *
+     * It is computed without rendering the image, so that the compiled file list can be built cheaply.
+     */
+    public function hash(StartupImageDefinition $definition): string;
+
+    public function render(StartupImageDefinition $definition): string;
+}

--- a/src/StartupImage/TemplateStartupImageRenderer.php
+++ b/src/StartupImage/TemplateStartupImageRenderer.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\StartupImage;
+
+use function assert;
+use RuntimeException;
+use function spl_object_id;
+use SpomkyLabs\PwaBundle\Dto\StartupImages;
+use SpomkyLabs\PwaBundle\Dto\StartupImageTheme;
+use SpomkyLabs\PwaBundle\Service\ManifestBuilder;
+use SpomkyLabs\PwaBundle\Service\SourceImage;
+use SpomkyLabs\PwaBundle\Service\SourceImageResolver;
+use SpomkyLabs\PwaBundle\Service\StartupImagesBuilder;
+use function sprintf;
+use Twig\Environment;
+
+/**
+ * Describes the image with a Twig template, and hands the document over to a renderer that paints it.
+ *
+ * The template is rendered by the application's own Twig environment: its globals, extensions and
+ * filters are the ones it already knows.
+ */
+final class TemplateStartupImageRenderer implements StartupImageRendererInterface
+{
+    /**
+     * The geometry the template is rendered with when its output is being fingerprinted rather than
+     * shown. Both orientations are probed: a template that only lays out its subtitle in landscape would
+     * otherwise keep its fingerprint when that branch is edited.
+     */
+    private const FINGERPRINT_PROBES = [[600, 800], [800, 600]];
+
+    private readonly StartupImages $startupImages;
+
+    /**
+     * @var array<int, string>
+     */
+    private array $fingerprints = [];
+
+    /**
+     * @var array<int, SourceImage>
+     */
+    private array $sources = [];
+
+    public function __construct(
+        private readonly null|Environment $twig,
+        private readonly null|HtmlRendererInterface $htmlRenderer,
+        private readonly SourceImageResolver $sourceImageResolver,
+        private readonly ManifestBuilder $manifestBuilder,
+        StartupImagesBuilder $startupImagesBuilder,
+    ) {
+        $this->startupImages = $startupImagesBuilder->create();
+    }
+
+    /**
+     * Why this renderer cannot work, ready to be thrown, or null when it is ready.
+     *
+     * Configuring a template is a deliberate act: what is missing is named, rather than silently falling
+     * back to the plain image the application chose not to ask for.
+     */
+    public function getUnavailabilityReason(): null|string
+    {
+        $requirement = match (true) {
+            $this->twig === null => 'Twig is not available. Install "symfony/twig-bundle".',
+            $this->htmlRenderer === null => sprintf(
+                'nothing can paint the document. Install "symfony/panther" together with a Chrome driver, or register a service implementing "%s".',
+                HtmlRendererInterface::class
+            ),
+            default => null,
+        };
+        if ($requirement === null) {
+            return null;
+        }
+
+        return sprintf(
+            'The startup images are described by the template "%s", but %s',
+            $this->startupImages->template ?? '',
+            $requirement
+        );
+    }
+
+    public function hash(StartupImageDefinition $definition): string
+    {
+        return hash('xxh128', sprintf(
+            '%s%d%d%s%s',
+            $this->getFingerprint($definition),
+            $definition->width,
+            $definition->height,
+            $definition->orientation->value,
+            $definition->colorScheme->value,
+        ));
+    }
+
+    public function render(StartupImageDefinition $definition): string
+    {
+        if ($this->htmlRenderer === null) {
+            $this->fail();
+        }
+
+        return $this->htmlRenderer->capture($this->renderHtml($definition), $definition->width, $definition->height);
+    }
+
+    public function renderHtml(StartupImageDefinition $definition): string
+    {
+        if ($this->twig === null) {
+            $this->fail();
+        }
+        $template = $this->startupImages->template;
+        assert($template !== null, 'The template renderer was used without a template being configured.');
+
+        return $this->twig->render($template, $this->getContext($definition));
+    }
+
+    private function fail(): never
+    {
+        throw new RuntimeException($this->getUnavailabilityReason() ?? 'The startup images cannot be rendered.');
+    }
+
+    /**
+     * A fingerprint of everything the rendering is made of, the geometry aside: the template and whatever
+     * it pulls in, the variables it is handed, and the source image inlined in it.
+     */
+    private function getFingerprint(StartupImageDefinition $definition): string
+    {
+        $key = spl_object_id($definition->theme);
+        if (isset($this->fingerprints[$key])) {
+            return $this->fingerprints[$key];
+        }
+
+        $probes = '';
+        foreach (self::FINGERPRINT_PROBES as [$width, $height]) {
+            $probes .= $this->renderHtml(StartupImageDefinition::create(
+                $definition->theme,
+                $definition->colorScheme,
+                Device::create('fingerprint', $width, $height, 1),
+                $width <= $height ? Orientation::PORTRAIT : Orientation::LANDSCAPE,
+            ));
+        }
+
+        return $this->fingerprints[$key] = hash('xxh128', $probes);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getContext(StartupImageDefinition $definition): array
+    {
+        $manifest = $this->manifestBuilder->create();
+        $source = $this->getSource($definition->theme);
+        $themeColor = $definition->colorScheme === ColorScheme::DARK
+            ? $manifest->darkThemeColor ?? $manifest->themeColor
+            : $manifest->themeColor;
+
+        return [
+            /* Geometry of the image, in device pixels. */
+            'width' => $definition->width,
+            'height' => $definition->height,
+            'orientation' => $definition->orientation->value,
+            /* Geometry of the device, in CSS pixels. */
+            'device_width' => $definition->device->width,
+            'device_height' => $definition->device->height,
+            'pixel_ratio' => $definition->device->pixelRatio,
+            'device_name' => $definition->device->name,
+            /* Appearance. */
+            'color_scheme' => $definition->colorScheme->value,
+            'background_color' => $definition->theme->backgroundColor,
+            'theme_color' => $themeColor,
+            /* The application, as the manifest declares it. Values are the raw configured ones: run them
+               through the "trans" filter with the "pwa" domain when they are translation keys. */
+            'app_name' => $manifest->name,
+            'short_name' => $manifest->shortName,
+            'description' => $manifest->description,
+            'lang' => $manifest->lang,
+            'dir' => $manifest->dir,
+            /* The source image, inlined: the browser paints the document from a temporary file, with no
+               application URL to resolve an asset against. */
+            'icon' => $source->getDataUri(),
+            'icon_svg' => $source->isSvg() ? $source->content : null,
+            /* Whatever the application chose to declare under "context". */
+            'context' => $definition->theme->context,
+        ];
+    }
+
+    private function getSource(StartupImageTheme $theme): SourceImage
+    {
+        return $this->sources[spl_object_id($theme)] ??= $this->sourceImageResolver->resolve(
+            $theme->src,
+            $theme->svgAttributes
+        );
+    }
+}

--- a/templates/StartupImage/default.html.twig
+++ b/templates/StartupImage/default.html.twig
@@ -1,0 +1,101 @@
+{#
+    The startup image iOS shows while the application boots.
+
+    Extend it rather than copy it when only a piece of it has to change:
+
+        {% extends '@SpomkyLabsPwa/StartupImage/default.html.twig' %}
+        {% block subtitle %}<p class="subtitle">{{ context.baseline }}</p>{% endblock %}
+
+    Everything is sized against `--unit`, a hundredth of the shorter side, so that a layout written once
+    holds from an iPhone SE to an iPad Pro. Lengths are in device pixels: the document is painted at the
+    exact pixel size of the screen, with no device pixel ratio applied on top.
+
+    Available variables: width, height, orientation, device_width, device_height, pixel_ratio, device_name,
+    color_scheme, background_color, theme_color, app_name, short_name, description, lang, dir, icon,
+    icon_svg, context.
+#}
+<!DOCTYPE html>
+<html lang="{{ lang|default('en') }}"{% if dir %} dir="{{ dir }}"{% endif %}>
+<head>
+    <meta charset="utf-8">
+    <title>{{ app_name|default('') }}</title>
+    <style>
+        {% block stylesheet %}
+        :root {
+            --unit: {{ min(width, height) / 100 }}px;
+            --background-color: {{ background_color|default('#ffffff') }};
+            --text-color: {{ theme_color|default('#000000') }};
+        }
+
+        * { box-sizing: border-box; }
+
+        html, body {
+            margin: 0;
+            padding: 0;
+            width: {{ width }}px;
+            height: {{ height }}px;
+            overflow: hidden;
+        }
+
+        body {
+            background-color: var(--background-color);
+            color: var(--text-color);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: calc(var(--unit) * 4);
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            text-align: center;
+            {# The safe area of a notched screen is not honoured by the startup image, so the content is
+               kept away from the edges by hand. #}
+            padding: calc(var(--unit) * 10);
+        }
+
+        .logo {
+            width: calc(var(--unit) * {{ orientation == 'portrait' ? 34 : 22 }});
+            height: auto;
+            max-height: calc(var(--unit) * 40);
+        }
+
+        .name {
+            margin: 0;
+            font-size: calc(var(--unit) * {{ orientation == 'portrait' ? 7 : 6 }});
+            font-weight: 600;
+            letter-spacing: -0.02em;
+            line-height: 1.15;
+        }
+
+        .subtitle {
+            margin: 0;
+            font-size: calc(var(--unit) * {{ orientation == 'portrait' ? 4 : 3.5 }});
+            font-weight: 400;
+            opacity: 0.7;
+            line-height: 1.3;
+        }
+        {% endblock %}
+    </style>
+</head>
+<body>
+{% block body %}
+    {% block logo %}
+        {% if icon is not empty %}
+            <img class="logo" src="{{ icon }}" alt="">
+        {% endif %}
+    {% endblock %}
+
+    {% block name %}
+        {% set displayed_name = context.name|default(app_name) %}
+        {% if displayed_name is not empty %}
+            <h1 class="name">{{ displayed_name }}</h1>
+        {% endif %}
+    {% endblock %}
+
+    {% block subtitle %}
+        {% if context.subtitle is defined and context.subtitle is not empty %}
+            <p class="subtitle">{{ context.subtitle }}</p>
+        {% endif %}
+    {% endblock %}
+{% endblock %}
+</body>
+</html>

--- a/tests/DummyHtmlRenderer.php
+++ b/tests/DummyHtmlRenderer.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Tests;
+
+use SpomkyLabs\PwaBundle\StartupImage\HtmlRendererInterface;
+use function sprintf;
+
+/**
+ * Records the documents it is handed instead of starting a browser to paint them.
+ *
+ * @internal
+ */
+final class DummyHtmlRenderer implements HtmlRendererInterface
+{
+    /**
+     * @var list<array{html: string, width: int, height: int}>
+     */
+    public array $captures = [];
+
+    public function capture(string $html, int $width, int $height): string
+    {
+        $this->captures[] = [
+            'html' => $html,
+            'width' => $width,
+            'height' => $height,
+        ];
+
+        return sprintf('PNG %dx%d', $width, $height);
+    }
+}

--- a/tests/Functional/BrowserConfigTest.php
+++ b/tests/Functional/BrowserConfigTest.php
@@ -13,6 +13,7 @@ use SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface;
 use SpomkyLabs\PwaBundle\Service\BasePathResolver;
 use SpomkyLabs\PwaBundle\Service\FaviconsBuilder;
 use SpomkyLabs\PwaBundle\Service\FaviconsCompiler;
+use SpomkyLabs\PwaBundle\Service\SourceImageResolver;
 use function sprintf;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -64,7 +65,6 @@ final class BrowserConfigTest extends KernelTestCase
 
         $favicons = new Favicons();
         $favicons->enabled = true;
-        $favicons->useStartImage = false;
         $favicons->default = $default;
         $favicons->tileColor = '#ffffff';
 
@@ -75,8 +75,7 @@ final class BrowserConfigTest extends KernelTestCase
         return new FaviconsCompiler(
             static::getContainer()->get(ImageProcessorInterface::class),
             new FaviconsBuilder($denormalizer, []),
-            static::getContainer()->get('asset_mapper'),
-            null,
+            static::getContainer()->get(SourceImageResolver::class),
             static::getContainer()->get(BasePathResolver::class),
             false
         );

--- a/tests/Functional/DarkThemeFaviconsTrait.php
+++ b/tests/Functional/DarkThemeFaviconsTrait.php
@@ -11,6 +11,7 @@ use SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface;
 use SpomkyLabs\PwaBundle\Service\BasePathResolver;
 use SpomkyLabs\PwaBundle\Service\FaviconsBuilder;
 use SpomkyLabs\PwaBundle\Service\FaviconsCompiler;
+use SpomkyLabs\PwaBundle\Service\SourceImageResolver;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 /**
@@ -32,7 +33,6 @@ trait DarkThemeFaviconsTrait
 
         $favicons = new Favicons();
         $favicons->enabled = true;
-        $favicons->useStartImage = true;
         $favicons->lowResolution = true;
         $favicons->default = $default;
         $favicons->dark = $dark;
@@ -44,8 +44,7 @@ trait DarkThemeFaviconsTrait
         return new FaviconsCompiler(
             static::getContainer()->get(ImageProcessorInterface::class),
             new FaviconsBuilder($denormalizer, []),
-            static::getContainer()->get('asset_mapper'),
-            null,
+            static::getContainer()->get(SourceImageResolver::class),
             static::getContainer()->get(BasePathResolver::class),
             false
         );

--- a/tests/Functional/FaviconsColorSchemeTest.php
+++ b/tests/Functional/FaviconsColorSchemeTest.php
@@ -17,31 +17,6 @@ final class FaviconsColorSchemeTest extends KernelTestCase
     use DarkThemeFaviconsTrait;
 
     #[Test]
-    public function startupImageMediaQueriesAreNotNested(): void
-    {
-        // Given
-        static::bootKernel();
-        $compiler = $this->createCompilerWithDarkTheme();
-
-        // When
-        $medias = $this->getMediaAttributes($compiler, 'apple-touch-startup-image');
-
-        // Then
-        static::assertNotEmpty($medias, 'no startup image was generated');
-        foreach ($medias as $media) {
-            static::assertStringStartsNotWith(
-                '((',
-                $media,
-                'the media query nests a condition in parentheses, which Safari only parses from 16.4 on: ' . $media
-            );
-            static::assertMatchesRegularExpression(
-                '/^\(device-width: .+\) and \(prefers-color-scheme: (light|dark)\)$/',
-                $media
-            );
-        }
-    }
-
-    #[Test]
     public function faviconsAreDeclinedForBothColorSchemes(): void
     {
         // Given

--- a/tests/Functional/StartupImageColorSchemeTest.php
+++ b/tests/Functional/StartupImageColorSchemeTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\Test;
+use SpomkyLabs\PwaBundle\Service\StartupImagesCompiler;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * @internal
+ */
+final class StartupImageColorSchemeTest extends KernelTestCase
+{
+    use StartupImagesCompilerTrait;
+
+    #[Test]
+    public function mediaQueriesAreNotNested(): void
+    {
+        // Given
+        static::bootKernel();
+        $compiler = $this->createStartupImagesCompiler(withDarkTheme: true);
+
+        // When
+        $medias = $this->getMediaAttributes($compiler);
+
+        // Then
+        static::assertNotEmpty($medias, 'no startup image was generated');
+        foreach ($medias as $media) {
+            static::assertStringStartsNotWith(
+                '((',
+                $media,
+                'the media query nests a condition in parentheses, which Safari only parses from 16.4 on: ' . $media
+            );
+            static::assertMatchesRegularExpression(
+                '/^\(device-width: .+\) and \(prefers-color-scheme: (light|dark)\)$/',
+                $media
+            );
+        }
+    }
+
+    #[Test]
+    public function aSingleColorSchemeCarriesNoColorSchemeCondition(): void
+    {
+        // Given
+        static::bootKernel();
+        $compiler = $this->createStartupImagesCompiler();
+
+        // When
+        $medias = $this->getMediaAttributes($compiler);
+
+        // Then
+        static::assertNotEmpty($medias, 'no startup image was generated');
+        foreach ($medias as $media) {
+            static::assertStringNotContainsString('prefers-color-scheme', $media);
+        }
+    }
+
+    #[Test]
+    public function eachColorSchemeGetsItsOwnImage(): void
+    {
+        // Given
+        static::bootKernel();
+        $compiler = $this->createStartupImagesCompiler(withDarkTheme: true);
+
+        // When
+        $urls = [];
+        foreach ($compiler->getFiles() as $url => $file) {
+            $urls[] = $url;
+        }
+
+        // Then
+        static::assertSame($urls, array_unique($urls), 'a startup image is generated more than once');
+        static::assertCount(84, $urls, '21 devices, two orientations, two color schemes');
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function getMediaAttributes(StartupImagesCompiler $compiler): array
+    {
+        $medias = [];
+        foreach ($compiler->getFiles() as $file) {
+            if (preg_match('/ media="([^"]+)"/', (string) $file->html, $matches) === 1) {
+                $medias[] = $matches[1];
+            }
+        }
+
+        return $medias;
+    }
+}

--- a/tests/Functional/StartupImageDeviceCoverageTest.php
+++ b/tests/Functional/StartupImageDeviceCoverageTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SpomkyLabs\PwaBundle\Tests\Functional;
 
 use PHPUnit\Framework\Attributes\Test;
-use SpomkyLabs\PwaBundle\Service\FaviconsCompiler;
+use SpomkyLabs\PwaBundle\Service\StartupImagesCompiler;
 use function sprintf;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
@@ -19,8 +19,8 @@ final class StartupImageDeviceCoverageTest extends KernelTestCase
     {
         // Given
         static::bootKernel();
-        $compiler = static::getContainer()->get(FaviconsCompiler::class);
-        static::assertInstanceOf(FaviconsCompiler::class, $compiler);
+        $compiler = static::getContainer()->get(StartupImagesCompiler::class);
+        static::assertInstanceOf(StartupImagesCompiler::class, $compiler);
 
         // When
         $medias = [];

--- a/tests/Functional/StartupImageOrientationTest.php
+++ b/tests/Functional/StartupImageOrientationTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace SpomkyLabs\PwaBundle\Tests\Functional;
 
 use PHPUnit\Framework\Attributes\Test;
-use SpomkyLabs\PwaBundle\Service\FaviconsCompiler;
+use SpomkyLabs\PwaBundle\Service\StartupImagesCompiler;
 use function sprintf;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
@@ -19,8 +19,8 @@ final class StartupImageOrientationTest extends KernelTestCase
     {
         // Given
         self::bootKernel();
-        $compiler = self::getContainer()->get(FaviconsCompiler::class);
-        static::assertInstanceOf(FaviconsCompiler::class, $compiler);
+        $compiler = self::getContainer()->get(StartupImagesCompiler::class);
+        static::assertInstanceOf(StartupImagesCompiler::class, $compiler);
 
         // When
         $html = '';

--- a/tests/Functional/StartupImageTemplateTest.php
+++ b/tests/Functional/StartupImageTemplateTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Tests\Functional;
+
+use function count;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use SpomkyLabs\PwaBundle\Service\StartupImagesCompiler;
+use SpomkyLabs\PwaBundle\Tests\DummyHtmlRenderer;
+use function sprintf;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * @internal
+ */
+final class StartupImageTemplateTest extends KernelTestCase
+{
+    use StartupImagesCompilerTrait;
+
+    private const TEMPLATE = '@SpomkyLabsPwa/StartupImage/default.html.twig';
+
+    #[Test]
+    public function theDocumentIsPaintedAtTheSizeOfTheDevice(): void
+    {
+        // Given
+        static::bootKernel();
+        $htmlRenderer = new DummyHtmlRenderer();
+        $compiler = $this->createStartupImagesCompiler(template: self::TEMPLATE, htmlRenderer: $htmlRenderer);
+
+        // When
+        foreach ($compiler->getFiles() as $file) {
+            $file->getData();
+        }
+
+        // Then
+        static::assertCount(42, $htmlRenderer->captures, '21 devices in two orientations');
+        foreach ($htmlRenderer->captures as $capture) {
+            static::assertStringContainsString(
+                sprintf('width: %dpx', $capture['width']),
+                $capture['html'],
+                'the document does not declare the width it is painted at'
+            );
+            static::assertStringContainsString(sprintf('height: %dpx', $capture['height']), $capture['html']);
+        }
+    }
+
+    #[Test]
+    public function theTemplateIsHandedTheApplicationAndItsOwnContext(): void
+    {
+        // Given
+        static::bootKernel();
+        $htmlRenderer = new DummyHtmlRenderer();
+        $compiler = $this->createStartupImagesCompiler(
+            template: self::TEMPLATE,
+            htmlRenderer: $htmlRenderer,
+            context: [
+                'subtitle' => 'Your daily companion',
+            ]
+        );
+
+        // When
+        foreach ($compiler->getFiles() as $file) {
+            $file->getData();
+            break;
+        }
+
+        // Then
+        static::assertNotEmpty($htmlRenderer->captures);
+        $html = $htmlRenderer->captures[0]['html'];
+        static::assertStringContainsString('Your daily companion', $html, 'the free context is not exposed');
+        static::assertStringContainsString('pwa.name', $html, 'the manifest name is not exposed');
+        static::assertStringContainsString('data:image/svg+xml;base64,', $html, 'the source image is not inlined');
+        static::assertStringContainsString('#ffffff', $html, 'the background color is not exposed');
+    }
+
+    #[Test]
+    public function theLayoutFollowsTheOrientation(): void
+    {
+        // Given
+        static::bootKernel();
+        $htmlRenderer = new DummyHtmlRenderer();
+        $compiler = $this->createStartupImagesCompiler(template: self::TEMPLATE, htmlRenderer: $htmlRenderer);
+
+        // When
+        foreach ($compiler->getFiles() as $file) {
+            $file->getData();
+        }
+
+        // Then
+        $portrait = array_values(array_filter(
+            $htmlRenderer->captures,
+            static fn (array $capture): bool => $capture['width'] < $capture['height']
+        ));
+        $landscape = array_values(array_filter(
+            $htmlRenderer->captures,
+            static fn (array $capture): bool => $capture['width'] > $capture['height']
+        ));
+
+        static::assertNotEmpty($portrait);
+        static::assertNotEmpty($landscape);
+        static::assertCount(count($portrait), $landscape, 'every device shall be declined in both orientations');
+        // The shipped template gives the logo a different share of the screen in landscape, where the
+        // vertical room is what runs out first.
+        static::assertStringContainsString('--unit) * 34)', $portrait[0]['html']);
+        static::assertStringContainsString('--unit) * 22)', $landscape[0]['html']);
+    }
+
+    #[Test]
+    public function theFileNameFollowsWhatTheTemplateProduces(): void
+    {
+        // The images are served as immutable: a template edit that left the URL alone would be a stale
+        // image in every cache between the application and the device.
+
+        // Given
+        static::bootKernel();
+
+        // When
+        $first = $this->collectUrls('Your daily companion');
+        $again = $this->collectUrls('Your daily companion');
+        $other = $this->collectUrls('Something else entirely');
+
+        // Then
+        static::assertSame($first, $again, 'the same template and context shall produce the same file names');
+        static::assertSame([], array_intersect($first, $other), 'a context change shall rename every image');
+    }
+
+    #[Test]
+    public function aMissingBrowserIsReportedRatherThanWorkedAround(): void
+    {
+        // Configuring a template is deliberate: falling back to the plain image would silently ship
+        // something the application chose not to ask for.
+
+        // Given
+        static::bootKernel();
+        $compiler = $this->createStartupImagesCompiler(template: self::TEMPLATE);
+
+        // When
+        $exception = $this->captureFailure($compiler);
+
+        // Then
+        static::assertInstanceOf(RuntimeException::class, $exception);
+        static::assertStringContainsString(sprintf(
+            'The startup images are described by the template "%s", but nothing can paint the document.',
+            self::TEMPLATE
+        ), $exception->getMessage());
+    }
+
+    #[Test]
+    public function aMissingTwigIsReportedRatherThanWorkedAround(): void
+    {
+        // Given
+        static::bootKernel();
+        $compiler = $this->createStartupImagesCompiler(
+            template: self::TEMPLATE,
+            htmlRenderer: new DummyHtmlRenderer(),
+            withTwig: false
+        );
+
+        // When
+        $exception = $this->captureFailure($compiler);
+
+        // Then
+        static::assertInstanceOf(RuntimeException::class, $exception);
+        static::assertStringContainsString(
+            'Twig is not available. Install "symfony/twig-bundle".',
+            $exception->getMessage()
+        );
+    }
+
+    #[Test]
+    public function noTemplateKeepsThePlainImage(): void
+    {
+        // Given
+        static::bootKernel();
+        $htmlRenderer = new DummyHtmlRenderer();
+        $compiler = $this->createStartupImagesCompiler(htmlRenderer: $htmlRenderer);
+
+        // When
+        $files = iterator_to_array($compiler->getFiles());
+        foreach ($files as $file) {
+            $file->getData();
+        }
+
+        // Then
+        static::assertCount(42, $files);
+        static::assertSame([], $htmlRenderer->captures, 'no browser shall be needed without a template');
+    }
+
+    /**
+     * The compilation is driven by hand rather than with expectException(), whose message assertion is
+     * spelled differently from one PHPUnit major to the next.
+     */
+    private function captureFailure(StartupImagesCompiler $compiler): null|RuntimeException
+    {
+        try {
+            iterator_to_array($compiler->getFiles());
+        } catch (RuntimeException $exception) {
+            return $exception;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function collectUrls(string $subtitle): array
+    {
+        $compiler = $this->createStartupImagesCompiler(
+            template: self::TEMPLATE,
+            htmlRenderer: new DummyHtmlRenderer(),
+            context: [
+                'subtitle' => $subtitle,
+            ]
+        );
+
+        $urls = [];
+        foreach ($compiler->getFiles() as $url => $file) {
+            $urls[] = $url;
+        }
+
+        return $urls;
+    }
+}

--- a/tests/Functional/StartupImagesCompilerTrait.php
+++ b/tests/Functional/StartupImagesCompilerTrait.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Tests\Functional;
+
+use SpomkyLabs\PwaBundle\Dto\Asset;
+use SpomkyLabs\PwaBundle\Dto\StartupImages;
+use SpomkyLabs\PwaBundle\Dto\StartupImageTheme;
+use SpomkyLabs\PwaBundle\ImageProcessor\ImageProcessorInterface;
+use SpomkyLabs\PwaBundle\Service\BasePathResolver;
+use SpomkyLabs\PwaBundle\Service\ManifestBuilder;
+use SpomkyLabs\PwaBundle\Service\SourceImageResolver;
+use SpomkyLabs\PwaBundle\Service\StartupImagesBuilder;
+use SpomkyLabs\PwaBundle\Service\StartupImagesCompiler;
+use SpomkyLabs\PwaBundle\StartupImage\DeviceCatalog;
+use SpomkyLabs\PwaBundle\StartupImage\HtmlRendererInterface;
+use SpomkyLabs\PwaBundle\StartupImage\IconStartupImageRenderer;
+use SpomkyLabs\PwaBundle\StartupImage\TemplateStartupImageRenderer;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+/**
+ * Builds a startup images compiler out of a hand-written configuration, which lets a test declare a dark
+ * color scheme or a template without the whole test kernel having to.
+ *
+ * @internal
+ */
+trait StartupImagesCompilerTrait
+{
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function createStartupImagesCompiler(
+        bool $withDarkTheme = false,
+        null|string $template = null,
+        null|HtmlRendererInterface $htmlRenderer = null,
+        array $context = [],
+        bool $withTwig = true,
+    ): StartupImagesCompiler {
+        $default = new StartupImageTheme();
+        $default->src = Asset::create('pwa/1920x1920.svg');
+        $default->backgroundColor = '#ffffff';
+        $default->context = $context;
+
+        $startupImages = new StartupImages();
+        $startupImages->enabled = true;
+        $startupImages->template = $template;
+        $startupImages->default = $default;
+
+        if ($withDarkTheme) {
+            // A source of its own, so that only the URLs that structurally collide show up as duplicates.
+            $dark = new StartupImageTheme();
+            $dark->src = Asset::create('pwa/screenshots/600x400.svg');
+            $dark->backgroundColor = '#000000';
+            $dark->context = $context;
+            $startupImages->dark = $dark;
+        }
+
+        $denormalizer = $this->createStub(DenormalizerInterface::class);
+        $denormalizer->method('denormalize')
+            ->willReturn($startupImages);
+        $builder = new StartupImagesBuilder($denormalizer, []);
+
+        $container = static::getContainer();
+        $sourceImageResolver = $container->get(SourceImageResolver::class);
+
+        return new StartupImagesCompiler(
+            $builder,
+            new DeviceCatalog(),
+            new IconStartupImageRenderer(
+                $container->get(ImageProcessorInterface::class),
+                $sourceImageResolver,
+                $builder
+            ),
+            new TemplateStartupImageRenderer(
+                $withTwig ? $container->get('twig') : null,
+                $htmlRenderer,
+                $sourceImageResolver,
+                $container->get(ManifestBuilder::class),
+                $builder
+            ),
+            $container->get(BasePathResolver::class),
+            false
+        );
+    }
+}


### PR DESCRIPTION
A startup image could only ever be one thing: the favicon source, scaled down and centred over a background colour. This adds a `pwa.startup_images` section where an optional Twig template describes the document iOS paints while the application boots — free positioning, the application name, a static subtitle, whatever the layout calls for.

## Before / after

Same logo, same background colour, same device (iPhone 15 Pro, 1179×2556).

<table>
<tr>
<td align="center"><b>Today</b><br><sub>the favicon source, scaled down and centred</sub></td>
<td align="center"><b>With a template</b><br><sub>name, baseline, publisher and version, laid out freely</sub></td>
</tr>
<tr>
<td><img width="260" alt="Today" src="https://github.com/user-attachments/assets/a19ba3cb-57d8-4957-8c65-b32fc6b07eb5"></td>
<td><img width="260" alt="With a template" src="https://github.com/user-attachments/assets/f17d734b-c051-452a-acd9-9872682aa6c2"></td>
</tr>
</table>

The same template in landscape, in dark mode, and on an iPad. One file, one configuration:

<table>
<tr>
<td colspan="2" align="center"><sub>iPhone 15 Pro, landscape — 2556×1179</sub></td>
</tr>
<tr>
<td colspan="2"><img width="540" alt="Landscape" src="https://github.com/user-attachments/assets/5f6c1471-d23d-49ce-9ac8-3b997625f7b3"></td>
</tr>
<tr>
<td align="center"><sub>Dark colour scheme</sub></td>
<td align="center"><sub>iPad Pro 11" — 1668×2420</sub></td>
</tr>
<tr>
<td><img width="260" alt="Dark" src="https://github.com/user-attachments/assets/55edcceb-e565-44be-9ceb-b5b107798a2e"></td>
<td><img width="260" alt="iPad" src="https://github.com/user-attachments/assets/2f517684-4fb9-412e-8ca4-bf87b24829a6"></td>
</tr>
</table>

The shipped template asks for no design work at all, and a hand-written one can go somewhere else entirely:

<table>
<tr>
<td align="center"><b>Out of the box</b><br><sub><code>@SpomkyLabsPwa/StartupImage/default.html.twig</code>, unmodified</sub></td>
<td align="center"><b>A register of its own</b><br><sub>a hand-written template: serif wordmark, rule, discreet mark</sub></td>
</tr>
<tr>
<td><img width="260" alt="Out of the box" src="https://github.com/user-attachments/assets/1f55cd20-2b6f-4c98-a122-2a16648f0864"></td>
<td><img width="260" alt="A register of its own" src="https://github.com/user-attachments/assets/aa1b2eeb-1711-4742-b9a7-00cb02a2e9e2"></td>
</tr>
</table>

## Configuration

```yaml
pwa:
    startup_images:
        template: 'pwa/startup_image.html.twig'
        context:
            subtitle: 'Identify every plant, even offline.'
        default:
            src: 'images/logo.svg'
            background_color: '#f6fbf7'
        dark:
            src: 'images/logo-dark.svg'
            background_color: '#04140c'
```

Nothing to configure to keep today's behaviour: without a `template`, the images still come out of the image processor, and an existing `pwa.favicons` configuration drives them exactly as before.

## The template contract

Rendered by the application's own Twig environment, so its globals, extensions and filters are the ones it already knows.

| | |
|---|---|
| Geometry of the image, in device pixels | `width`, `height`, `orientation` |
| Geometry of the device, in CSS pixels | `device_width`, `device_height`, `pixel_ratio`, `device_name` |
| The manifest | `app_name`, `short_name`, `description`, `theme_color`, `lang`, `dir` |
| Appearance | `color_scheme` (`light`/`dark`), `background_color` |
| The source image, inlined | `icon` (data URI), `icon_svg` (raw SVG, or null) |
| The application's own | `context` |

`@SpomkyLabsPwa/StartupImage/default.html.twig` ships as a starting point, with `stylesheet`, `logo`, `name` and `subtitle` blocks to extend rather than copy:

```twig
{% extends '@SpomkyLabsPwa/StartupImage/default.html.twig' %}
{% block subtitle %}<p class="subtitle">{{ context.baseline }}</p>{% endblock %}
```

Everything is sized against `--unit`, a hundredth of the shorter side, so one layout holds from an iPhone SE to an iPad Pro.

## What it costs

The document is painted by a headless Chrome driven by Panther, behind `HtmlRendererInterface` so an application can substitute its own. That is a build-time requirement, and it is only paid for when a template is configured.

Configuring a template is a deliberate act, so a missing requirement is named rather than worked around — silently falling back to the plain image would ship something the application chose not to ask for:

```
The startup images are described by the template "pwa/startup_image.html.twig", but
nothing can paint the document. Install "symfony/panther" together with a Chrome driver,
or register a service implementing "…\StartupImage\HtmlRendererInterface".
```

The three cases are told apart: Twig missing, renderer missing (both raised before a single image is generated), and a Chrome driver that will not start — whose opaque Panther exception is wrapped with the remedy.

## Structure

Startup images leave `FaviconsCompiler`, which they had nothing to do with beyond sharing a source image.

- `StartupImagesCompiler` owns them and delegates the pixels to a `StartupImageRendererInterface`: `IconStartupImageRenderer` for the historical rendering, `TemplateStartupImageRenderer` for the new one.
- The 42 hand-written media query blocks become 21 `Device` entries in a `DeviceCatalog`, declined over both orientations. A device described once can no longer disagree with itself between portrait and landscape.
- `SourceImageResolver` holds the asset resolution that `FaviconsCompiler` and the new code would otherwise duplicate, and recognises the media type so a template can inline the source.
- `FaviconsCompiler` loses 240 lines, along with the `media` and `imageScale` keys of its size table that only the startup images ever set.

## Backward compatibility

`favicons.use_start_image` is deprecated and now seeds `startup_images.enabled`; the images borrow their source, background colour, border radius and SVG attributes from the favicon of the same colour scheme.

Verified rather than assumed: the generated URLs and `<link>` tags were diffed before and after on the test configuration — **identical, content hashes included** — for an application that configures no template.

## Tests

`castor phpunit`: 263 tests, green. ECS, Rector, PHPStan and Deptrac (0 violations) all pass.

Nine new tests cover device coverage and orientation on the new compiler, colour scheme media queries, the template contract, the fact that a file name follows what the template produces, and that a missing renderer is reported instead of worked around. The template path is exercised through a stub `HtmlRendererInterface`, so no browser is needed in CI.

One gap, stated plainly: `ChromeHtmlRenderer` has no integration test. It was validated by driving Chromium directly at every device size, not through Panther.

## Not in this PR

The documentation. `phpwa-doc/favicons/startup-images.md` still describes startup images as a favicon setting and needs rewriting around the new section.

