### PR TITLE
Stop the bundle from deprecating itself over PageCache

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -127,15 +127,6 @@ parameters:
 			path: ../src/Dto/Workbox.php
 
 		-
-			rawMessage: '''
-				Property $resourceCaches references deprecated class SpomkyLabs\PwaBundle\Dto\PageCache in its type:
-				since 1.2.0 and will be removed in 2.0.0. Use ResourceCache instead.
-			'''
-			identifier: property.deprecatedClass
-			count: 1
-			path: ../src/Dto/Workbox.php
-
-		-
 			rawMessage: 'Call to function assert() with true will always evaluate to true.'
 			identifier: function.alreadyNarrowedType
 			count: 1

--- a/.ci-tools/rector.php
+++ b/.ci-tools/rector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\StmtsAwareInterface\RemoveDeadInstanceOfAssertRector;
 use Rector\Doctrine\Set\DoctrineSetList;
+use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Renaming\Rector\Name\RenameClassRector;
@@ -47,6 +48,9 @@ $builder->withSkip([
     // The $requests argument of RequestStack::__construct() only exists from Symfony 7.2 on, while
     // composer.json allows ^7.0. Applying this would break the --prefer-lowest test job.
     PushRequestToRequestStackConstructorRector::class,
+    // "PageCache" is an alias of a class it declares deprecated, so it has to name itself. Written as
+    // a ::class constant, PHPStan reports the file for referencing the very class it deprecates.
+    StringClassNameToClassConstantRector::class => [__DIR__ . '/../src/Dto/PageCache.php'],
 ]);
 $builder->withParallel();
 $builder->withImportNames();

--- a/src/Dto/PageCache.php
+++ b/src/Dto/PageCache.php
@@ -4,9 +4,39 @@ declare(strict_types=1);
 
 namespace SpomkyLabs\PwaBundle\Dto;
 
-/**
- * @deprecated since 1.2.0 and will be removed in 2.0.0. Use ResourceCache instead.
+/*
+ * "ResourceCache" is documented as final, and this class was the only thing extending it -- the bundle
+ * itself. Symfony's DebugClassLoader cannot tell an inheritance the bundle owns from one an application
+ * wrote, so every application running in dev or test was told off for a subclass it had no part in and
+ * no way to remove.
+ *
+ * The name is kept as an alias instead. An application still resolves it, still passes any
+ * "instanceof ResourceCache" check, and now gets a deprecation naming what to migrate to.
+ *
+ * The alias comes first: a test suite that turns deprecations into exceptions would otherwise leave the
+ * class undefined.
  */
-final class PageCache extends ResourceCache
-{
+class_alias(ResourceCache::class, 'SpomkyLabs\\PwaBundle\\Dto\\PageCache');
+
+trigger_deprecation(
+    'spomky-labs/phpwa',
+    '1.2.0',
+    'The "%s" class is deprecated and will be removed in 2.0.0. Use "%s" instead.',
+    'SpomkyLabs\\PwaBundle\\Dto\\PageCache',
+    ResourceCache::class
+);
+
+/*
+ * Never executed. Composer's classmap generator parses rather than runs, so this declaration is what
+ * maps the name to this file: an application installed with --classmap-authoritative has no PSR-4
+ * fallback, and would not find the class at all without it.
+ */
+/** @phpstan-ignore if.alwaysFalse (the branch is meant for the parser, never for PHP) */
+if (false) {
+    /**
+     * @deprecated since 1.2.0 and will be removed in 2.0.0. Use ResourceCache instead.
+     */
+    final class PageCache extends ResourceCache
+    {
+    }
 }

--- a/src/Dto/Workbox.php
+++ b/src/Dto/Workbox.php
@@ -23,7 +23,7 @@ final class Workbox
     public FontCache $fontCache;
 
     /**
-     * @var array<PageCache>
+     * @var array<ResourceCache>
      */
     #[SerializedName('resource_caches')]
     public array $resourceCaches = [];


### PR DESCRIPTION
Fixes #427. Closes #170.

## The report

Every application running the bundle in `dev` or `test` was told off:

```
The "SpomkyLabs\PwaBundle\Dto\ResourceCache" class is considered final.
It may change without further notice as of its next major version.
You should not extend it from "SpomkyLabs\PwaBundle\Dto\PageCache".
```

Nothing in the application was at fault, and nothing it could do would silence it — which is why #170 came back as #427 after being closed.

## Why it happened

`ResourceCache` is documented `@final`, and the only class extending it was `PageCache` — the bundle's own, deprecated since 1.2.0. The annotation was written as a docblock rather than the PHP keyword precisely so that `PageCache` could keep extending it. Symfony's `DebugClassLoader` cannot tell an inheritance the bundle owns from one an application wrote, so it reported the bundle's own subclass to every user.

Reproduced on `1.5.x` before the change:

```php
DebugClassLoader::enable();
class_exists(PageCache::class);
DebugClassLoader::checkClasses();
// DEPRECATION: The "…\ResourceCache" class is considered final. […]
```

## The fix

`PageCache` keeps no state and adds no behaviour of its own; it survives only so that an application that named it still compiles. It becomes an alias:

```php
class_alias(ResourceCache::class, 'SpomkyLabs\PwaBundle\Dto\PageCache');
```

After the change, the same script prints an actionable deprecation instead:

```
DEPRECATION: Since spomky-labs/phpwa 1.2.0: The "…\Dto\PageCache" class is
deprecated and will be removed in 2.0.0. Use "…\Dto\ResourceCache" instead.
```

| | Before | After |
|---|---|---|
| `@final` deprecation | on every request in dev/test | gone |
| Using `PageCache` | silent | deprecation naming the replacement |
| `instanceof ResourceCache` | true | true |
| Inherited properties | intact | intact |
| `get_class()` | `PageCache` | `ResourceCache` |

That last row is the one observable difference. It would only matter to code comparing `get_class($x) === PageCache::class` on a configuration DTO nobody instantiates by hand.

## Why the unreachable declaration

```php
if (false) {
    /** @deprecated since 1.2.0 … */
    final class PageCache extends ResourceCache {}
}
```

Composer's classmap generator parses rather than runs. Without a declaration it can see, `PageCache` never enters the classmap — and an application installed with `--classmap-authoritative` has no PSR-4 fallback, so the class would simply not be found. Verified both ways:

```
$ composer dump-autoload --classmap-authoritative
$ php -r 'require "vendor/autoload.php"; var_dump(class_exists("…\Dto\PageCache"));'
bool(true)
```

The block also carries the `@deprecated` annotation for IDEs and static analysis, which an alias alone cannot express.

## Also in this PR

- `Workbox::$resourceCaches` is documented `array<ResourceCache>` rather than `array<PageCache>`. The property has been filled with `ResourceCache` instances since the option was renamed; only the annotation lagged. Its baseline entry goes with it.
- A Rector skip, which is the price of the alias: written as a `::class` constant, the file would be reported by PHPStan for referencing the very class it deprecates. The two tools disagree, and the skip records which one wins and why.

## Tests

`castor phpunit`: 139 tests, green. ECS, Rector and Deptrac (0 violations) pass, and PHPStan is clean under PHP 8.4 — the version the CI static-analysis job runs.

The behaviour above was verified by hand rather than asserted in a test: `DebugClassLoader` reports on shutdown, which does not sit well inside PHPUnit. Worth adding if you would rather have it locked down.

## Branch

Targets `1.5.x`, the oldest maintained branch carrying the bug, to be cascaded up to `1.6.x`.
