### PR TITLE
Deprecate the Workbox version and the CDN

### DIFF
--- a/src/Resources/config/definition/service_worker.php
+++ b/src/Resources/config/definition/service_worker.php
@@ -118,12 +118,18 @@ return static function (DefinitionConfigurator $definition): void {
             if (isset($v['config'])) {
                 return $v;
             }
-            $v['config'] = [
-                'use_cdn' => $v['use_cdn'] ?? false,
-                'version' => $v['version'] ?? '7.4.1',
-                'workbox_public_url' => $v['workbox_public_url'] ?? '/workbox',
-                'debug' => $v['debug'] ?? true,
-            ];
+            // Only the keys the application actually set are carried over. Writing the whole section with
+            // its defaults would make the bundle trigger its own deprecations, for options nobody
+            // configured. What is left out is what "WorkboxConfig" already defaults to.
+            $config = [];
+            foreach (['use_cdn', 'version', 'workbox_public_url'] as $key) {
+                if (array_key_exists($key, $v)) {
+                    $config[$key] = $v[$key];
+                }
+            }
+            if ($config !== []) {
+                $v['config'] = $config;
+            }
 
             return $v;
         })
@@ -131,11 +137,11 @@ return static function (DefinitionConfigurator $definition): void {
         ->children()
         ->booleanNode('use_cdn')
         ->defaultFalse()
-        ->info('Whether to use the local workbox or the CDN.')
+        ->info('Whether to use the local workbox or the CDN. Deprecated: the bundled files are the supported ones.')
         ->setDeprecated(
             'spomky-labs/phpwa',
             '1.5.0',
-            'The "%node%" option is deprecated and will be removed in 2.0.0. use "config.use_cdn" instead.'
+            'The "%path%.%node%" option is deprecated and will be removed in 2.0.0. The bundle serves the Workbox version it ships from your own application.'
         )
         ->end()
         ->arrayNode('google_fonts')
@@ -164,9 +170,9 @@ return static function (DefinitionConfigurator $definition): void {
         ->setDeprecated(
             'spomky-labs/phpwa',
             '1.5.0',
-            'The "%node%" option is deprecated and will be removed in 2.0.0. use "config.version" instead.'
+            'The "%path%.%node%" option is deprecated and will be removed in 2.0.0. The bundle generates a service worker for the Workbox version it ships, and ships the only one it supports.'
         )
-        ->info('The version of workbox. Only "7.4.1" is shipped with the bundle: any other version requires the CDN.')
+        ->info('The version of workbox. Deprecated: the bundle ships "7.4.1" and generates code for it.')
         ->end()
         ->scalarNode('workbox_public_url')
         ->defaultValue('/workbox')
@@ -242,11 +248,21 @@ return static function (DefinitionConfigurator $definition): void {
         ->end()
         ->scalarNode('version')
         ->defaultValue('7.4.1')
-        ->info('The version of workbox. Only "7.4.1" is shipped with the bundle: any other version requires the CDN.')
+        ->setDeprecated(
+            'spomky-labs/phpwa',
+            '1.6.0',
+            'The "%path%.%node%" option is deprecated and will be removed in 2.0.0. The bundle generates a service worker for the Workbox version it ships, and ships the only one it supports.'
+        )
+        ->info('The version of workbox. Deprecated: the bundle ships "7.4.1" and generates code for it.')
         ->end()
         ->booleanNode('use_cdn')
         ->defaultFalse()
-        ->info('Whether to use the local workbox or the CDN.')
+        ->setDeprecated(
+            'spomky-labs/phpwa',
+            '1.6.0',
+            'The "%path%.%node%" option is deprecated and will be removed in 2.0.0. The bundle serves the Workbox version it ships from your own application.'
+        )
+        ->info('Whether to use the local workbox or the CDN. Deprecated: the bundled files are the supported ones.')
         ->end()
         ->scalarNode('workbox_public_url')
         ->defaultValue('/workbox')

--- a/tests/Functional/WorkboxLegacyConfigTest.php
+++ b/tests/Functional/WorkboxLegacyConfigTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Tests\Functional;
+
+use const E_USER_DEPRECATED;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\PwaBundle\Dto\WorkboxConfig;
+use SpomkyLabs\PwaBundle\SpomkyLabsPwaBundle;
+use Symfony\Component\Config\Definition\Configuration;
+use Symfony\Component\Config\Definition\Processor;
+
+/**
+ * The Workbox options predating the "config" section, and what an application configuring them ends up
+ * with.
+ *
+ * Normalization stopped writing the whole section with its own defaults, so that deprecating
+ * "config.use_cdn" and "config.version" would not report options nobody configured. What replaces the
+ * written defaults are the ones "WorkboxConfig" carries, and these tests are what holds the two together:
+ * the effective value is asserted for every shape a configuration can take, not the shape of the
+ * normalized array.
+ */
+final class WorkboxLegacyConfigTest extends TestCase
+{
+    /**
+     * @param array<string, mixed> $workbox
+     * @param array{use_cdn: bool, version: string, workbox_public_url: string, debug: bool} $expected
+     */
+    #[Test]
+    #[DataProvider('dataLegacyShapes')]
+    public function everyConfigurationShapeResolvesToTheSameValuesAsBefore(array $workbox, array $expected): void
+    {
+        static::assertSame($expected, $this->resolve($workbox));
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>, array<string, mixed>}>
+     */
+    public static function dataLegacyShapes(): iterable
+    {
+        $defaults = [
+            'use_cdn' => false,
+            'version' => '7.4.1',
+            'workbox_public_url' => '/workbox',
+            'debug' => true,
+        ];
+
+        yield 'Nothing configured' => [[], $defaults];
+
+        yield 'Legacy use_cdn' => [[
+            'use_cdn' => true,
+        ], [
+            ...$defaults,
+            'use_cdn' => true,
+        ]];
+
+        yield 'Legacy version' => [[
+            'version' => '7.3.0',
+        ], [
+            ...$defaults,
+            'version' => '7.3.0',
+        ]];
+
+        yield 'Legacy workbox_public_url' => [[
+            'workbox_public_url' => '/assets/workbox',
+        ], [
+            ...$defaults,
+            'workbox_public_url' => '/assets/workbox',
+        ]];
+
+        yield 'Every legacy option at once' => [[
+            'use_cdn' => true,
+            'version' => '7.3.0',
+            'workbox_public_url' => '/assets/workbox',
+        ], [
+            'use_cdn' => true,
+            'version' => '7.3.0',
+            'workbox_public_url' => '/assets/workbox',
+            'debug' => true,
+        ]];
+
+        yield 'Legacy option left at its default' => [[
+            'use_cdn' => false,
+        ], $defaults];
+
+        yield 'Current config section' => [[
+            'config' => [
+                'use_cdn' => true,
+                'version' => '7.3.0',
+            ],
+        ], [
+            ...$defaults,
+            'use_cdn' => true,
+            'version' => '7.3.0',
+        ]];
+
+        yield 'Partial config section' => [[
+            'config' => [
+                'debug' => false,
+            ],
+        ], [
+            ...$defaults,
+            'debug' => false,
+        ]];
+    }
+
+    /**
+     * The two spellings are not merged: a declared "config" section is taken as it stands, and the legacy
+     * options next to it are ignored. Undocumented, but longstanding, so it is pinned rather than changed
+     * under the cover of a deprecation.
+     */
+    #[Test]
+    public function aDeclaredConfigSectionIgnoresTheLegacyOptionsBesideIt(): void
+    {
+        $resolved = $this->resolve([
+            'use_cdn' => true,
+            'version' => '7.3.0',
+            'config' => [
+                'workbox_public_url' => '/assets/workbox',
+            ],
+        ]);
+
+        static::assertFalse($resolved['use_cdn']);
+        static::assertSame('7.4.1', $resolved['version']);
+        static::assertSame('/assets/workbox', $resolved['workbox_public_url']);
+    }
+
+    /**
+     * What normalization stopped writing has to be exactly what the DTO falls back on, or an application
+     * configuring nothing would silently change service worker.
+     */
+    #[Test]
+    public function theDtoDefaultsAreTheOnesNormalizationUsedToWrite(): void
+    {
+        $config = new WorkboxConfig();
+
+        static::assertFalse($config->useCDN);
+        static::assertSame('7.4.1', $config->version);
+        static::assertSame('/workbox', $config->workboxPublicUrl);
+        static::assertTrue($config->debug);
+    }
+
+    /**
+     * The effective Workbox settings of an application, the way the DTO resolves them: whatever the
+     * normalized configuration carries, over the defaults for what it leaves out.
+     *
+     * @param array<string, mixed> $workbox
+     *
+     * @return array{use_cdn: bool, version: string, workbox_public_url: string, debug: bool}
+     */
+    private function resolve(array $workbox): array
+    {
+        $configuration = [
+            'serviceworker' => [
+                'enabled' => true,
+                'src' => 'sw.js',
+            ],
+        ];
+        if ($workbox !== []) {
+            $configuration['serviceworker']['workbox'] = $workbox;
+        }
+
+        // The deprecations are the subject of another test case; here they are only in the way.
+        set_error_handler(static fn (): bool => true, E_USER_DEPRECATED);
+        try {
+            $processed = (new Processor())->processConfiguration(
+                new Configuration(new SpomkyLabsPwaBundle(), null, 'pwa'),
+                [$configuration]
+            );
+        } finally {
+            restore_error_handler();
+        }
+
+        /** @var array<string, mixed> $section */
+        $section = $processed['serviceworker']['workbox']['config'] ?? [];
+        $defaults = new WorkboxConfig();
+
+        return [
+            'use_cdn' => (bool) ($section['use_cdn'] ?? $defaults->useCDN),
+            'version' => (string) ($section['version'] ?? $defaults->version),
+            'workbox_public_url' => (string) ($section['workbox_public_url'] ?? $defaults->workboxPublicUrl),
+            'debug' => (bool) ($section['debug'] ?? $defaults->debug),
+        ];
+    }
+}

--- a/tests/Functional/WorkboxVersionDeprecationTest.php
+++ b/tests/Functional/WorkboxVersionDeprecationTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Tests\Functional;
+
+use const E_USER_DEPRECATED;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\PwaBundle\SpomkyLabsPwaBundle;
+use function str_contains;
+use Symfony\Component\Config\Definition\Configuration;
+use Symfony\Component\Config\Definition\Processor;
+
+/**
+ * The Workbox version and the CDN are deprecated: everything the bundle generates is written against the
+ * version it ships, so pinning another one only ever produces a service worker that breaks in the browser.
+ *
+ * What is tested here as much as the deprecation itself is its absence: the section used to be filled in
+ * with its own defaults during normalization, which would have made the bundle deprecate options no
+ * application ever configured.
+ */
+final class WorkboxVersionDeprecationTest extends TestCase
+{
+    #[Test]
+    public function anApplicationConfiguringNoWorkboxVersionIsNotDeprecated(): void
+    {
+        $deprecations = $this->process([
+            'serviceworker' => [
+                'enabled' => true,
+                'src' => 'sw.js',
+            ],
+        ]);
+
+        static::assertSame([], $deprecations);
+    }
+
+    #[Test]
+    public function theRemainingWorkboxOptionsAreNotDeprecated(): void
+    {
+        $deprecations = $this->process([
+            'serviceworker' => [
+                'enabled' => true,
+                'src' => 'sw.js',
+                'workbox' => [
+                    'config' => [
+                        'debug' => false,
+                        'workbox_public_url' => '/assets/workbox',
+                    ],
+                ],
+            ],
+        ]);
+
+        static::assertSame([], $deprecations);
+    }
+
+    #[Test]
+    public function pinningTheVersionIsDeprecated(): void
+    {
+        $deprecations = $this->process([
+            'serviceworker' => [
+                'enabled' => true,
+                'src' => 'sw.js',
+                'workbox' => [
+                    'config' => [
+                        'version' => '7.3.0',
+                    ],
+                ],
+            ],
+        ]);
+
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString('pwa.serviceworker.workbox.config.version', $deprecations[0]);
+        static::assertStringContainsString('will be removed in 2.0.0', $deprecations[0]);
+    }
+
+    #[Test]
+    public function usingTheCdnIsDeprecated(): void
+    {
+        $deprecations = $this->process([
+            'serviceworker' => [
+                'enabled' => true,
+                'src' => 'sw.js',
+                'workbox' => [
+                    'config' => [
+                        'use_cdn' => true,
+                    ],
+                ],
+            ],
+        ]);
+
+        static::assertCount(1, $deprecations);
+        static::assertStringContainsString('pwa.serviceworker.workbox.config.use_cdn', $deprecations[0]);
+    }
+
+    /**
+     * The options predating the "config" section still move into it, so that an application that never
+     * migrated keeps the service worker it had.
+     *
+     * Such an application is told twice, once for the spelling it used and once for the one the value was
+     * migrated into. Both are true, and both ask for the same thing, so the duplicate is left alone rather
+     * than silenced by dropping a deprecation that has been reported since 1.5.0.
+     */
+    #[Test]
+    public function theLegacyOptionsStillReachTheConfigSection(): void
+    {
+        $config = [];
+        $deprecations = $this->process([
+            'serviceworker' => [
+                'enabled' => true,
+                'src' => 'sw.js',
+                'workbox' => [
+                    'use_cdn' => true,
+                    'version' => '7.3.0',
+                ],
+            ],
+        ], $config);
+
+        static::assertTrue($config['serviceworker']['workbox']['config']['use_cdn']);
+        static::assertSame('7.3.0', $config['serviceworker']['workbox']['config']['version']);
+
+        $paths = array_map(
+            static fn (string $message): string => preg_replace('/^.*The "([^"]+)".*$/s', '$1', $message),
+            $deprecations
+        );
+        static::assertContains('pwa.serviceworker.workbox.use_cdn', $paths);
+        static::assertContains('pwa.serviceworker.workbox.version', $paths);
+    }
+
+    /**
+     * An application declaring nothing gets the defaults of the DTO rather than a "config" section written
+     * for it, which is what keeps the deprecations silent.
+     */
+    #[Test]
+    public function theConfigSectionIsNotFilledInForAnApplicationThatDeclaredNone(): void
+    {
+        $config = [];
+        $this->process([
+            'serviceworker' => [
+                'enabled' => true,
+                'src' => 'sw.js',
+            ],
+        ], $config);
+
+        static::assertArrayNotHasKey('config', $config['serviceworker']['workbox']);
+    }
+
+    /**
+     * @param array<string, mixed>       $configuration
+     * @param array<string, mixed>|null  $processed
+     *
+     * @return list<string>
+     */
+    private function process(array $configuration, null|array &$processed = null): array
+    {
+        $deprecations = [];
+        set_error_handler(static function (int $level, string $message) use (&$deprecations): bool {
+            $deprecations[] = $message;
+
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $processed = (new Processor())->processConfiguration(
+                new Configuration(new SpomkyLabsPwaBundle(), null, 'pwa'),
+                [$configuration]
+            );
+        } finally {
+            restore_error_handler();
+        }
+
+        return array_values(array_filter(
+            $deprecations,
+            static fn (string $message): bool => str_contains($message, 'Workbox') || str_contains($message, 'workbox')
+        ));
+    }
+}


### PR DESCRIPTION
Everything the bundle generates — the imports, the strategies, the plugins, the helpers — is written against the Workbox API of the version it ships. Letting an application pin another version, or fetch one from a CDN, offers a choice that can only produce a service worker breaking in the browser. Since #466 the bundle carries a single copy of the libraries, so serving that copy from the application is the only combination it actually supports.

`serviceworker.workbox.config.use_cdn` and `config.version` are therefore deprecated, for removal in 2.0.0. The flat spellings deprecated in 1.5.0 stop pointing at `config.*`, which would only move an application from one deprecated option to another; they now say what is going away.

## Not deprecating the bundle to itself

The normalization migrating the flat options into `config` used to write the whole section with its defaults, handing every application a `config.use_cdn` and a `config.version` it never configured. Deprecating the nodes without touching that would have reported both to everyone — the bundle telling its users off for what the bundle itself wrote, which is what #469 just fixed for `PageCache`.

Only the keys actually set are carried over now. What is left out is what `WorkboxConfig` already defaults to (`false` / `7.4.1` / `/workbox` / `true`), so the compiled service worker is unchanged.

## Backward compatibility

The options keep working until 2.0.0; only a notice is added. The observable change is the normalized configuration no longer carrying a `config` section for an application that declared none — no consumer reads it raw (the only raw access, `ResourceHintsBuilder`, reads the flat `workbox.use_cdn`), and the DTO defaults reproduce the previous values exactly. `debug:config pwa` shows fewer keys, which is the whole of it.

An application still on the flat spelling is told twice, once for what it wrote and once for what the value was migrated into. Both are true and ask for the same thing, so the duplicate is left rather than silenced by dropping a deprecation reported since 1.5.0.

## Tests

`WorkboxVersionDeprecationTest` covers the deprecations and, as much, their absence: an application configuring nothing, or configuring only `debug` and `workbox_public_url`, must stay silent.

`WorkboxLegacyConfigTest` pins every shape a Workbox configuration can take through its **effective values** rather than the shape of the normalized array — nothing declared, each legacy option alone, all of them at once, a legacy option left at its default, the current `config` spelling, and the longstanding precedence where a declared `config` section ignores the legacy options beside it. Removing a key from the migration makes three of them fail.

## Follow-up

The documentation still presents `use_cdn: true` as the supported way to use another version — [cdn-and-versions.md](https://github.com/Spomky-Labs/phpwa-doc/blob/1.6/the-service-worker/workbox/cdn-and-versions.md) and the 1.6.0 upgrade guide both need turning around once this lands.