### PR TITLE
Provide the raw text when symfony/translation is absent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,6 +81,7 @@
     "ext-imagick": "Required to generate icons (or GD).",
     "symfony/mime": "For generating and manipulating icons or screenshots",
     "symfony/filesystem": "For generating and manipulating icons or screenshots",
+    "symfony/translation": "To translate the manifest members (name, description, categories, shortcuts, screenshot labels)",
     "symfony/ux-icons": "For using SVG icons (e.g. for shortcuts)"
   }
 }

--- a/src/Dto/TranslatableTrait.php
+++ b/src/Dto/TranslatableTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SpomkyLabs\PwaBundle\Dto;
 
+use function class_exists;
 use function is_array;
 use Symfony\Component\Translation\TranslatableMessage;
 use Symfony\Contracts\Translation\TranslatableInterface;
@@ -19,7 +20,10 @@ trait TranslatableTrait
      */
     public function provideTranslation(null|string|array $data): null|string|TranslatableInterface|array
     {
-        if (! interface_exists(TranslatableInterface::class) || $data === null) {
+        // symfony/translation-contracts often comes along on its own (twig-bridge, security-core, …), so the
+        // interface being there proves nothing: TranslatableMessage lives in symfony/translation. Without that
+        // component there is nothing to translate with, and the configured text is the final text.
+        if ($data === null || ! class_exists(TranslatableMessage::class)) {
             return $data;
         }
         if (is_array($data)) {

--- a/tests/Unit/Dto/TranslatableTraitTest.php
+++ b/tests/Unit/Dto/TranslatableTraitTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpomkyLabs\PwaBundle\Tests\Unit\Dto;
+
+use const PHP_BINARY;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SpomkyLabs\PwaBundle\Dto\Manifest;
+use SpomkyLabs\PwaBundle\Dto\Screenshot;
+use SpomkyLabs\PwaBundle\Dto\Shortcut;
+use function sprintf;
+use Symfony\Component\Translation\TranslatableMessage;
+
+/**
+ * @internal
+ */
+final class TranslatableTraitTest extends TestCase
+{
+    #[Test]
+    public function theConfiguredTextIsWrappedWhenTheTranslationComponentIsInstalled(): void
+    {
+        $manifest = new Manifest();
+        $manifest->name = 'pwa.name';
+        $manifest->categories = ['pwa.categories.0'];
+
+        $name = $manifest->getName();
+        static::assertInstanceOf(TranslatableMessage::class, $name);
+        static::assertSame('pwa.name', $name->getMessage());
+        static::assertSame('pwa', $name->getDomain());
+
+        $categories = $manifest->getCategories();
+        static::assertContainsOnlyInstancesOf(TranslatableMessage::class, $categories);
+    }
+
+    #[Test]
+    public function nothingIsWrappedWhenThereIsNothingToTranslate(): void
+    {
+        $manifest = new Manifest();
+
+        static::assertNull($manifest->getName());
+        static::assertNull($manifest->getShortName());
+        static::assertNull($manifest->getDescription());
+        static::assertSame([], $manifest->getCategories());
+        static::assertNull((new Screenshot())->getLabel());
+        static::assertNull((new Shortcut())->getDescription());
+    }
+
+    /**
+     * symfony/translation-contracts is commonly installed on its own (twig-bridge, security-core, …), so the
+     * interface is there while TranslatableMessage is not. The bundle used to look at the interface only and
+     * blew up on the missing class, taking the whole manifest down with it.
+     */
+    #[Test]
+    public function theRawTextIsProvidedWhenTheTranslationComponentIsMissing(): void
+    {
+        $probe = __DIR__ . '/without_translation_component.php';
+        $command = sprintf('%s %s 2>&1', escapeshellarg(PHP_BINARY), escapeshellarg($probe));
+
+        $output = shell_exec($command);
+        static::assertIsString($output, 'the probe process could not be started');
+
+        $result = json_decode($output, true);
+        static::assertIsArray(
+            $result,
+            sprintf('the probe did not report anything usable, it printed: %s', $output)
+        );
+
+        if (isset($result['skipped'])) {
+            static::markTestSkipped($result['skipped']);
+        }
+
+        static::assertTrue($result['contracts_available'], 'the probe did not reproduce the reported setup');
+        static::assertSame('My Application', $result['name']);
+        static::assertSame('App', $result['short_name']);
+        static::assertSame('A very nice application', $result['description']);
+        static::assertSame(['books', 'education'], $result['categories']);
+        static::assertNull($result['untouched_description']);
+        static::assertSame("Today's agenda", $result['shortcut_name']);
+        static::assertSame('Events planned for today', $result['shortcut_description']);
+        static::assertSame('The home page', $result['screenshot_label']);
+    }
+}

--- a/tests/Unit/Dto/without_translation_component.php
+++ b/tests/Unit/Dto/without_translation_component.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Composer\Autoload\ClassLoader;
+use SpomkyLabs\PwaBundle\Dto\Manifest;
+use SpomkyLabs\PwaBundle\Dto\Screenshot;
+use SpomkyLabs\PwaBundle\Dto\Shortcut;
+use Symfony\Component\Translation\TranslatableMessage;
+use Symfony\Contracts\Translation\TranslatableInterface;
+
+// Probe run in a child process by TranslatableTraitTest: it hides symfony/translation from the autoloader and
+// reports what the DTOs hand over once TranslatableMessage is out of reach. A separate process is required
+// because a class cannot be unloaded once the test bootstrap has pulled it in.
+
+$loader = require dirname(__DIR__, 3) . '/vendor/autoload.php';
+assert($loader instanceof ClassLoader);
+$loader->setPsr4('Symfony\\Component\\Translation\\', []);
+
+if (class_exists(TranslatableMessage::class)) {
+    // An optimised classmap still reaches the component; there is nothing to observe here.
+    echo json_encode([
+        'skipped' => 'symfony/translation could not be hidden from the autoloader',
+    ], \JSON_THROW_ON_ERROR);
+
+    return;
+}
+
+$manifest = new Manifest();
+$manifest->name = 'My Application';
+$manifest->shortName = 'App';
+$manifest->description = 'A very nice application';
+$manifest->categories = ['books', 'education'];
+
+$shortcut = new Shortcut();
+$shortcut->name = "Today's agenda";
+$shortcut->description = 'Events planned for today';
+
+$screenshot = new Screenshot();
+$screenshot->label = 'The home page';
+
+echo json_encode([
+    'contracts_available' => interface_exists(TranslatableInterface::class),
+    'name' => $manifest->getName(),
+    'short_name' => $manifest->getShortName(),
+    'description' => $manifest->getDescription(),
+    'categories' => $manifest->getCategories(),
+    'untouched_description' => (new Manifest())->getDescription(),
+    'shortcut_name' => $shortcut->getName(),
+    'shortcut_description' => $shortcut->getDescription(),
+    'screenshot_label' => $screenshot->getLabel(),
+], \JSON_THROW_ON_ERROR);


### PR DESCRIPTION
Target branch: 1.5.x
Resolves issue # <!-- #-prefixed issue number(s), if any -->

- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

The bundle produces no manifest at all when `symfony/translation` is not installed, and it does so without saying anything useful.

`TranslatableTrait` decided whether it could build a `TranslatableMessage` by looking at `TranslatableInterface`:

```php
if (! interface_exists(TranslatableInterface::class) || $data === null) {
    return $data;
}
```

The two do not travel together. `TranslatableInterface` lives in **symfony/translation-contracts**, which `twig-bridge`, `security-core` and friends drag in on their own, while `TranslatableMessage` comes from **symfony/translation**. An application with Twig but without the translation component therefore walks past the guard, reaches `new TranslatableMessage(...)` and dies on `Error: Class "Symfony\Component\Translation\TranslatableMessage" not found` — in the middle of the serialization, so nothing is written.

The guard now asks for the class it is about to instantiate, and the configured text is handed over untouched when there is nothing to translate with. That covers every DTO using the trait: `Manifest`, `Shortcut`, `Screenshot`, `Widget` and `ShareTargetParameters`.

`symfony/translation` was also missing from `suggest`, which is where a reader would look to find out that translating the manifest members needs it.

### Tests

`TranslatableTraitTest` covers the three states: the text is wrapped when the component is installed, nothing is wrapped when there is nothing to translate, and the raw text comes through when the component is missing. The last one runs in a child process that drops the PSR-4 prefix from the autoloader — a class cannot be unloaded once the test bootstrap has pulled it in. Without the fix it fails and prints the original fatal.

Checked end to end as well: with `symfony/translation` hidden from the autoloader, `pwa:compile` used to blow up in `ManifestCompiler:125 → Data:42 → FileCompiler:61`; it now writes a `site.webmanifest` carrying the plain `name`, `categories`, screenshot labels and shortcuts.
